### PR TITLE
add theme support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9421,9 +9421,6 @@
       "integrity": "sha512-lTJOEKekN/4JI/eOEq0wLcx53co2N6vaT/XjBz46D1tvIVoUEyM0o2K6txW6gEotf31szFD/J1PbxmnbkGlK9A==",
       "dev": true,
       "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
       "engines": {
         "node": ">=12"
       }

--- a/projects/vanilla/src/app/colors.ts
+++ b/projects/vanilla/src/app/colors.ts
@@ -1,0 +1,226 @@
+/**
+ * It takes an array of 4 numbers (red, green, blue, alpha) and returns a string in
+ * the format of #RRGGBBAA
+ * @param  - red - The red value of the color (0-255)
+ * @returns A string.
+ */
+function RGBAToHexA([red, green, blue, alpha = 1]): string {
+  let r = red.toString(16);
+  let g = green.toString(16);
+  let b = blue.toString(16);
+  let a = Math.round(alpha * 255).toString(16);
+
+  if (r.length == 1) r = '0' + r;
+  if (g.length == 1) g = '0' + g;
+  if (b.length == 1) b = '0' + b;
+  if (a.length == 1) a = '0' + a;
+
+  return '#' + r + g + b + a;
+}
+
+/**
+ * It takes a hex string, converts it to an RGB array, then converts that array to
+ * an HSL array
+ * @param {string} h - hex color string
+ * @returns An array of strings with [ r, g, b ] values.
+ */
+function hexToHSL(h: string): [number, number, number] {
+  const [r, g, b] = hexToRGBA(h);
+  return RGBToHSL(r, g, b);
+}
+
+/**
+ * It takes a hex string, and returns an array of 4 numbers, representing the RGBA
+ * values of the hex string
+ * @param {string} h - string - The hex color string.
+ * @returns An array of 4 numbers with [ r, g, b, alpha ] values..
+ */
+function hexToRGBA(h: string): [number, number, number, number] {
+  let r = 0,
+    g = 0,
+    b = 0,
+    a = 1;
+
+  if (h.length === 4) {
+    h += 'f';
+  }
+  if (h.length === 7) {
+    h += 'ff';
+  }
+
+  if (h.length === 5) {
+    r = parseInt('0x' + h[1] + h[1]);
+    g = parseInt('0x' + h[2] + h[2]);
+    b = parseInt('0x' + h[3] + h[3]);
+    a = parseInt('0x' + h[4] + h[4]);
+  } else {
+    r = parseInt('0x' + h[1] + h[2]);
+    g = parseInt('0x' + h[3] + h[4]);
+    b = parseInt('0x' + h[5] + h[6]);
+    a = parseInt('0x' + h[7] + h[8]);
+  }
+
+  a = Number((a / 255).toFixed(3));
+  return [r, g, b, a];
+}
+
+/**
+ * Convert RGB values to HSL values, and return the HSL values as an array of
+ * strings.
+ * @param {number} r - red value
+ * @param {number} g - number - green channel value
+ * @param {number} b - number - blue channel value
+ * @returns An array of strings with [ r, g, b ] values.
+ */
+function RGBToHSL(r: number, g: number, b: number): [number, number, number] {
+  r /= 255;
+  g /= 255;
+  b /= 255;
+
+  // find channel values
+  let cmin = Math.min(r, g, b),
+    cmax = Math.max(r, g, b),
+    delta = cmax - cmin,
+    h = 0,
+    s = 0,
+    l = 0;
+
+  // hue
+  if (delta == 0) {
+    h = 0;
+  } else if (cmax == r) {
+    h = ((g - b) / delta) % 6;
+  } else if (cmax == g) {
+    h = (b - r) / delta + 2;
+  } else {
+    h = (r - g) / delta + 4;
+  }
+
+  h = Math.round(h * 60);
+  if (h < 0) h += 360;
+
+  // lightness
+  l = (cmax + cmin) / 2;
+
+  // staturation
+  s = delta == 0 ? 0 : delta / (1 - Math.abs(2 * l - 1));
+
+  s = +(s * 100).toFixed(0);
+  l = +(l * 100).toFixed(0);
+
+  return [h, s, l];
+}
+
+function HSLToHex([h, s, l]): string {
+  s /= 100;
+  l /= 100;
+
+  let c = (1 - Math.abs(2 * l - 1)) * s,
+      x = c * (1 - Math.abs((h / 60) % 2 - 1)),
+      m = l - c/2,
+      r = 0,
+      g = 0,
+      b = 0;
+
+  if (0 <= h && h < 60) {
+    r = c; g = x; b = 0;
+  } else if (60 <= h && h < 120) {
+    r = x; g = c; b = 0;
+  } else if (120 <= h && h < 180) {
+    r = 0; g = c; b = x;
+  } else if (180 <= h && h < 240) {
+    r = 0; g = x; b = c;
+  } else if (240 <= h && h < 300) {
+    r = x; g = 0; b = c;
+  } else if (300 <= h && h < 360) {
+    r = c; g = 0; b = x;
+  }
+  // Having obtained RGB, convert channels to hex
+  let red = Math.round((r + m) * 255).toString(16);
+  let green = Math.round((g + m) * 255).toString(16);
+  let blue = Math.round((b + m) * 255).toString(16);
+
+  // Prepend 0s, if necessary
+  if (red.length == 1)
+    red = "0" + red;
+  if (green.length == 1)
+    green = "0" + g;
+  if (blue.length == 1)
+    blue = "0" + b;
+
+  return "#" + r + g + b;
+}
+
+/**
+ * "Given a color and a weight, return a tinted version of that color."
+ *
+ * The first line of the function is a type annotation. It tells TypeScript that
+ * the function will return an array of four numbers
+ * @param {string} color - The color you want to tint.
+ * @param {number} weight - The weight of the tint. 0 is no tint, 1 is full tint.
+ * @returns An array of 4 numbers with [ r, g, b, alpha ] values.
+ */
+function tintColor(
+  color: string,
+  weight: number
+): [number, number, number, number] {
+  return mix('#fff', color, weight);
+}
+
+/**
+ * It takes a color and a weight, and returns a new color that is a mix of the
+ * original color and black
+ * @param {string} color - The color to be shaded.
+ * @param {number} weight - 0.0 - 1.0
+ * @returns An array of 4 numbers with [ r, g, b, alpha ] values.
+ */
+function shadeColor(
+  color: string,
+  weight: number
+): [number, number, number, number] {
+  return mix('#000', color, weight);
+}
+
+/**
+ * It takes two colors and a weight and returns a new color.
+ * @param {string} color1 - The first color to mix.
+ * @param {string} color2 - The color you want to mix with color1
+ * @param {number} weight - The weight of the first color.
+ * @returns An array of 4 numbers with [ r, g, b, alpha ] values.
+ */
+function mix(
+  color1: string,
+  color2: string,
+  weight: number
+): [number, number, number, number] {
+  const c1 = hexToRGBA(color1);
+  const c2 = hexToRGBA(color2);
+
+  const p = weight / 100;
+  const w = 2 * p - 1;
+  const a = c1[3] - c2[3];
+
+  const w1 = ((w * a === -1 ? w : (w + a) / (1 + w * a)) + 1) / 2.0;
+  const w2 = 1 - w1;
+
+  const r = Math.ceil(w1 * c1[0] + w2 * c2[0]);
+  const g = Math.ceil(w1 * c1[1] + w2 * c2[1]);
+  const b = Math.ceil(w1 * c1[2] + w2 * c2[2]);
+  const alpha = c1[3] * p + c2[3] * (1 - p);
+  return [r, g, b, alpha];
+}
+
+function darken(color: string, amount: number) {
+  let [h, s, l] = hexToHSL(color);
+  l += (l * amount / 100);
+  return HSLToHex([h, s, l]);
+}
+
+function lighten(color: string, amount: number) {
+  let [h, s, l] = hexToHSL(color);
+  l -= (l * amount / 100);
+  return HSLToHex([h, s, l]);
+}
+
+export { RGBAToHexA, RGBToHSL, hexToHSL, hexToRGBA };
+export { tintColor, shadeColor, mix, darken, lighten };

--- a/projects/vanilla/src/app/configurators/controls/color-picker.component.ts
+++ b/projects/vanilla/src/app/configurators/controls/color-picker.component.ts
@@ -5,19 +5,43 @@ import { ConfiguratorContext } from "@sinequa/ngx-ui-builder";
   selector: 'sq-color-picker',
   template: `
   <label for="color-{{property}}" class="form-label" *ngIf="label">{{label}}</label>
-  <input
-    type="color"
-    id="color-{{property}}"
-    class="form-control form-control-color mb-2"
-    [(ngModel)]="color"
-    (ngModelChangeDebounced)="context.configChanged()"/>
-  `
+  <div class="color-picker-wrapper mb-2">
+    <input [uib-tooltip]="tooltip" i18n-uib-tooltip i18n
+      type="color"
+      id="color-{{property}}"
+      class="form-control-color"
+      [(ngModel)]="color"
+      (ngModelChangeDebounced)="context.configChanged()"/>
+  </div>
+  `,
+  styles: [`
+    :host {
+      width: 100px;
+    }
+
+    .color-picker-wrapper {
+      overflow: hidden;
+      width: 48px;
+      height: 48px;
+      border-radius: 50%;
+      box-shadow: 1px 1px 3px 0px grey;
+      margin: auto;
+    }
+
+    .color-picker-wrapper input[type=color] {
+      width: 150%;
+      height: 150%;
+      padding: 0;
+      margin: -25%;
+    }
+  `]
 })
 export class ColorPickerComponent implements OnChanges {
   @Input() context: ConfiguratorContext;
   @Input() property: string;
   @Input() label?: string;
   @Input() defaultColor = '#ffffff';
+  @Input() tooltip?: string;
 
   _path: string[];
 

--- a/projects/vanilla/src/app/configurators/global-configurator.component.ts
+++ b/projects/vanilla/src/app/configurators/global-configurator.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from "@angular/core";
+import { Component, Input, OnInit } from "@angular/core";
 import { ConfiguratorContext } from "@sinequa/ngx-ui-builder";
 
 @Component({
@@ -6,8 +6,56 @@ import { ConfiguratorContext } from "@sinequa/ngx-ui-builder";
   template: `
   <div role="alert" class="alert alert-warning">This component controls global styling options (colors, fonts, etc.). The component itself has no visible appearance.</div>
 
-  <sq-color-picker [context]="context" property="backgroundColor" label="Background color"></sq-color-picker>
-  <sq-color-picker [context]="context" property="gradientColor" label="Gradient color"></sq-color-picker>
+  <div class="d-flex gap-2">
+    <sq-color-picker [context]="context" [defaultColor]="background" property="backgroundColor" label="Background" tooltip="Select the background color"></sq-color-picker>
+    <sq-color-picker [context]="context" [defaultColor]="gradient" property="gradientColor" label="Gradient" tooltip="Select last color to create a gradient backgound"></sq-color-picker>
+  </div>
+
+  <div class="d-flex gap-2">
+    <sq-color-picker [context]="context" [defaultColor]="brand" property="brandingColor" label="Branding" tooltip="Select color for navigation and facet bar"></sq-color-picker>
+    <sq-color-picker [context]="context" [defaultColor]="primary" property="primaryColor" label="Primary" tooltip="Select primary color for buttons"></sq-color-picker>
+    <sq-color-picker [context]="context" [defaultColor]="secondary" property="secondaryColor" label="Secondary" tooltip="Select secondary color used by buttons"></sq-color-picker>
+  </div>
+
+  <!-- color variants -->
+  <details id="colors-variants" class="mb-2 mt-2">
+    <summary>Colors variants</summary>
+    <div class="card p-2">
+      <div class="d-flex flex-column">
+        <h6>Brand variants</h6>
+        <div class="d-flex gap-1">
+          <div *ngFor="let color of [100,200,300,400,500]" class="d-flex rounded-1 justify-content-center align-items-center" [style]="'width: 35px;height: 35px;background-color: var(--brand-'+ color + '); color: var(--switch-' + color + ');'">{{ color }}</div>
+        </div>
+      </div>
+      <div class="d-flex flex-column mt-1">
+        <h6>Primary variants</h6>
+        <div class="d-flex gap-1">
+          <div *ngFor="let color of [100,200,300,400,500]" class="d-flex rounded-1 justify-content-center align-items-center" [style]="'width: 35px;height: 35px;background-color: var(--primary-'+ color + '); color: var(--switch-' + color + ');'">{{ color }}</div>
+        </div>
+      </div>
+      <div class="d-flex flex-column mt-1">
+        <h6>Secondary variants</h6>
+        <div class="d-flex gap-1">
+          <div *ngFor="let color of [100,200,300,400,500]" class="d-flex rounded-1 justify-content-center align-items-center" [style]="'width: 35px;height: 35px;background-color: var(--secondary-'+ color + '); color: var(--switch-' + color + ');'">{{ color }}</div>
+        </div>
+      </div>
+    </div>
+  </details>
+
+  <hr/>
+
+  <div class="d-flex flex-column gap-1">
+    <h6>Nav/Card Header Text Color</h6>
+    <div class="d-flex gap-1">
+      <div *ngFor="let color of [1,2,3];let index = index;" style="flex-basis: 33%" class="form-check form-check-inline d-flex align-items-center gap-1" >
+        <input name="textColorOptions" class="form-check-input" type="radio" [ngModel]="context.config.textColor" value="text{{ index+1 }}" (click)="setTextColor(index)">
+        <div class="rounded-1 p-1" [style]="'background-color: var(--brand); color: var(--text'+color+');'">{{ textColors[index] }}</div>
+      </div>
+    </div>
+  </div>
+
+  <hr/>
+
   <sq-img-selector [context]="context" param="backgroundImage" description="Background image" class="d-block mb-2"></sq-img-selector>
 
   <label for="font">Font</label>
@@ -16,7 +64,7 @@ import { ConfiguratorContext } from "@sinequa/ngx-ui-builder";
   </select>
   `
 })
-export class GlobalConfiguratorComponent {
+export class GlobalConfiguratorComponent implements OnInit {
   @Input() context: ConfiguratorContext;
 
   fonts = [
@@ -26,4 +74,27 @@ export class GlobalConfiguratorComponent {
     {name: "Monospace", value: 'SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace'},
     {name: "Fantasy", value: "fantasy"}
   ]
+
+  textColors = ['darker', 'neutral', 'lighter'];
+
+  background?;
+  gradient?;
+
+  brand?;
+  primary?;
+  secondary?;
+
+  ngOnInit(): void {
+    this.background = getComputedStyle(document.body).getPropertyValue('--background-color').trim();
+    this.gradient = getComputedStyle(document.body).getPropertyValue('--gradient-color').trim();
+
+    this.brand = getComputedStyle(document.body).getPropertyValue('--brand-300').trim();
+    this.primary = getComputedStyle(document.body).getPropertyValue('--primary-300').trim();
+    this.secondary = getComputedStyle(document.body).getPropertyValue('--secondary-300').trim();
+  }
+
+  setTextColor(index: number) {
+    this.context.config.textColor = `text${index+1}`;
+    this.context.configChanged();
+  }
 }

--- a/projects/vanilla/src/app/global.component.ts
+++ b/projects/vanilla/src/app/global.component.ts
@@ -1,5 +1,9 @@
 import { Component, Input, OnChanges, SimpleChanges } from "@angular/core";
 
+import { hexToHSL, hexToRGBA, RGBAToHexA, shadeColor, tintColor } from "./colors";
+
+type ColorVariants = "primary" | "secondary" | "brand";
+
 @Component({
   selector: 'sq-global',
   template: ``
@@ -9,6 +13,10 @@ export class GlobalComponent implements OnChanges {
   @Input() gradientColor?: string;
   @Input() backgroundImage?: string;
   @Input() fontFamily?: string;
+  @Input() brandingColor?: string;
+  @Input() primaryColor?: string;
+  @Input() secondaryColor?: string;
+  @Input() textColor?: string;
 
 
   ngOnChanges(changes: SimpleChanges): void {
@@ -31,13 +39,80 @@ export class GlobalComponent implements OnChanges {
       document.body.style.backgroundSize = 'cover';
     }
     else if(this.backgroundColor) {
-      if(this.gradientColor) {
-        document.body.style.backgroundImage = `linear-gradient(${this.backgroundColor},${this.gradientColor})`;
-        document.body.style.backgroundAttachment = 'fixed';
-      }
-      else {
-        document.body.style.backgroundColor = this.backgroundColor;
-      }
+      document.documentElement.style.setProperty('--background-color', this.backgroundColor);
+    }
+    if(this.gradientColor) {
+      document.documentElement.style.setProperty('--gradient-color', this.gradientColor);
+    }
+
+    if (this.primaryColor) {
+      this.setColorVariants(this.primaryColor, "primary");
+      document.documentElement.style.setProperty('--primary', `var(--primary-300)`);
+      const [r, g, b] = hexToRGBA(this.primaryColor);
+      document.documentElement.style.setProperty('--primary-rgb',`${r},${g},${b}` );
+    }
+
+    if (this.secondaryColor) {
+      this.setColorVariants(this.secondaryColor, "secondary");
+      document.documentElement.style.setProperty('--secondary', `var(--secondary-300)`);
+      const [r, g, b] = hexToRGBA(this.secondaryColor);
+      document.documentElement.style.setProperty('--secondary-rgb',`${r},${g},${b}` );
+    }
+
+    if (this.brandingColor) {
+      const [h, s, l] = hexToHSL(this.brandingColor);
+
+      document.documentElement.style.setProperty('--brand-hue', `${h}`);
+      document.documentElement.style.setProperty('--brand-saturation', `${s}%`);
+      document.documentElement.style.setProperty('--brand-lightness', `${l}%`);
+
+      this.setColorVariants(this.brandingColor, "brand");
+      document.documentElement.style.setProperty('--brand', `var(--brand-300)`);
+
+      document.documentElement.style.setProperty('--text1', 'hsl(var(--brand-hue) var(--brand-saturation) 10%)');
+      document.documentElement.style.setProperty('--text2', 'hsl(var(--brand-hue) 20% 70%)');
+      document.documentElement.style.setProperty('--text3', 'hsl(var(--brand-hue), calc(80% - var(--brand-saturation)), calc(180% - var(--brand-lightness)) )');
+      document.documentElement.style.setProperty('--text3-hover', 'hsl(var(--brand-hue), var(--brand-saturation), calc(160% - var(--brand-lightness)) )');
+      document.documentElement.style.setProperty('--sq-text', 'var(--text3)');
+      document.documentElement.style.setProperty('--sq-text-hover', 'var(--text2)');
+    }
+
+    if (this.textColor) {
+      document.documentElement.style.setProperty('--sq-text', `var(--${this.textColor})`)
+    }
+  }
+
+  setColorVariants900(color: string, name: ColorVariants) {
+    // variants from 100-400
+    for (let index = 1; index < 5; index++) {
+      const value = RGBAToHexA(tintColor(color, 100 - (20 * index)));
+      document.documentElement.style.setProperty(`--${name}-${index * 100}`, value);
+    }
+
+    // base variant is 500
+    document.documentElement.style.setProperty(`--${name}-500`, color);
+
+    // variants from 500-900
+    for (let index = 1; index < 5; index++) {
+      const value = RGBAToHexA(shadeColor(color, 20 * index));
+      document.documentElement.style.setProperty(`--${name}-${index * 100 + 500}`, value);
+    }
+  }
+
+  setColorVariants(color: string, name: ColorVariants) {
+    // variants from 100-200
+    for (let index = 1; index < 3; index++) {
+      const value = RGBAToHexA(tintColor(color, 100 - (20 * index)));
+      document.documentElement.style.setProperty(`--${name}-${index * 100}`, value);
+    }
+
+    // base variant is 300
+    document.documentElement.style.setProperty(`--${name}-300`, color);
+
+    // variants from 400-500
+    for (let index = 1; index < 3; index++) {
+      const value = RGBAToHexA(shadeColor(color, 20 * index));
+      document.documentElement.style.setProperty(`--${name}-${index * 100 + 300}`, value);
     }
   }
 }

--- a/projects/vanilla/src/app/home/home.component.html
+++ b/projects/vanilla/src/app/home/home.component.html
@@ -66,7 +66,16 @@
     </ng-template>
 
     <ng-template uib-template="global" display="Global styles" title="An invisible component whose purpose is to inject global styles (colors, fonts, etc.) in the application" let-config>
-        <sq-global [backgroundColor]="config.backgroundColor" [gradientColor]="config.gradientColor" [backgroundImage]="config.backgroundImage" [fontFamily]="config.fontFamily"></sq-global>
+        <sq-global
+          [backgroundColor]="config.backgroundColor"
+          [gradientColor]="config.gradientColor"
+          [backgroundImage]="config.backgroundImage"
+          [brandingColor]="config.brandingColor"
+          [primaryColor]="config.primaryColor"
+          [secondaryColor]="config.secondaryColor"
+          [textColor]="config.textColor"
+          [fontFamily]="config.fontFamily">
+        </sq-global>
     </ng-template>
 </uib-zone>
 

--- a/projects/vanilla/src/app/search-form/search-form.component.scss
+++ b/projects/vanilla/src/app/search-form/search-form.component.scss
@@ -30,9 +30,7 @@
 .form-control:focus-within {
     color: #495057;
     background-color: #fff;
-    border-color: #80bdff;
     outline: 0;
-    box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.25);
 }
 .form-control.is-invalid:focus-within {
     border-color: #dc3545;

--- a/projects/vanilla/src/app/search/search.component.html
+++ b/projects/vanilla/src/app/search/search.component.html
@@ -1,6 +1,6 @@
 <div class="nav-wrapper">
     <!-- Navbar with app icon, search form, and menus -->
-    <nav class="navbar navbar-expand-sm" [ngClass]="{'navbar-light bg-light': !isDark(), 'navbar-dark bg-dark': isDark()}">
+    <nav class="navbar navbar-expand-sm">
         <uib-zone id="navbar" class="container-xl" *ngIf="loginService.complete">
             <!-- Application logo -->
             <ng-template uib-template="logo" display="App logo" let-config>
@@ -50,7 +50,16 @@
             </ng-template>
 
             <ng-template uib-template="global" display="Global styles" title="An invisible component whose purpose is to inject global styles (colors, fonts, etc.) in the application" let-config>
-                <sq-global [backgroundColor]="config.backgroundColor" [gradientColor]="config.gradientColor" [backgroundImage]="config.backgroundImage" [fontFamily]="config.fontFamily"></sq-global>
+              <sq-global
+                [backgroundColor]="config.backgroundColor"
+                [gradientColor]="config.gradientColor"
+                [backgroundImage]="config.backgroundImage"
+                [primaryColor]="config.primaryColor"
+                [secondaryColor]="config.secondaryColor"
+                [brandingColor]="config.brandingColor"
+                [textColor]="config.textColor"
+                [fontFamily]="config.fontFamily">
+              </sq-global>
             </ng-template>
         </uib-zone>
 
@@ -352,7 +361,7 @@
                 </ng-template>
             </uib-zone>
 
-        </div>
+          </div>
     </div>
 </div>
 

--- a/projects/vanilla/src/index.html
+++ b/projects/vanilla/src/index.html
@@ -7,7 +7,7 @@
          <meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no">
          <link rel="icon" type="image/x-icon" href="assets/favicon.ico">
     </head>
-    <body style="margin: 0;">
+    <body>
         <app>
             <div style="height: 100vh;display: flex;flex-direction: column;justify-content: center;align-items: center;">
                 <img id="sinequa-logo" style="margin-bottom: 1rem;" src="assets/sinequa-logo-light-lg.png" width="160px">

--- a/projects/vanilla/src/proxy.conf.json
+++ b/projects/vanilla/src/proxy.conf.json
@@ -1,19 +1,10 @@
 {
-    "/api": {
-      "target": "https://vm-su-sba.sinequa.com:13343",
-      "secure": true,
-      "changeOrigin": true
-    },
-    
-    "/xdownload": {
-        "target": "https://vm-su-sba.sinequa.com:13343",
-        "secure": true,
-        "changeOrigin": true
-    },
-    
-    "/saml/redirect": {
-        "target": "https://vm-su-sba.sinequa.com:13343",
-        "secure": true,
-        "changeOrigin": true
-    }
+    "context": [
+        "/api",
+        "/xdownload",
+        "/saml/redirect"
+    ],
+    "target": "https://vm-su-sba.sinequa.com:13343",
+    "secure": true,
+    "changeOrigin": true
 }

--- a/projects/vanilla/src/styles/_uibuilder.scss
+++ b/projects/vanilla/src/styles/_uibuilder.scss
@@ -1,0 +1,6 @@
+// <!-- ui-builder -->
+.uib-zone.edited {
+  sq-facet-tree .list-group.list-group-flush, sq-facet-list .facet-results-scrollable, sq-facet-date > div {
+    max-height: 100px;
+  }
+}

--- a/projects/vanilla/src/styles/app.scss
+++ b/projects/vanilla/src/styles/app.scss
@@ -18,9 +18,9 @@ $container-max-widths: (
 );
 
 // Bootstrap styles
-@import "bootstrap/scss/bootstrap";
+@import "../../../../node_modules/bootstrap/scss/bootstrap";
 
-@import "node_modules/@sinequa/ngx-ui-builder/styles/ui-builder";
+@import "../../../../node_modules/@sinequa/ngx-ui-builder/styles/ui-builder";
 
 // Fontawesome
 $fa-font-path: "~@fortawesome/fontawesome-free/webfonts";
@@ -31,17 +31,6 @@ $fa-font-path: "~@fortawesome/fontawesome-free/webfonts";
 
 @import "vis-network/dist/dist/vis-network.min.css";
 
-// override btn-light and btn-light:hover's background-color as in Boostrap 5 is too lighter
-.btn-light {
-  &.active, &:hover {
-      --bg-color: 226, 230, 234;
-      background-color: rgb(var(--bg-color));
-      border-color: #dae0e5;
-  }
-  &.active:hover {
-      background-color: rgb(var(--bg-color), .6);
-  }
-}
 
 .btn-link {
   text-decoration: none;
@@ -68,226 +57,15 @@ sq-validation-message {
 
 // Sinequa components stylesheets
 $action-menu-breakpoint: sm;
-@import "node_modules/@sinequa/components/action/bootstrap/action.scss";
-@import "node_modules/@sinequa/components/notification/bootstrap/notification.scss";
-@import "node_modules/@sinequa/components/metadata/metadata.scss";
-@import "node_modules/@sinequa/components/advanced/bootstrap/advanced.scss";
+@import "../../../../node_modules/@sinequa/components/action/bootstrap/action.scss";
+@import "../../../../node_modules/@sinequa/components/notification/bootstrap/notification.scss";
+@import "../../../../node_modules/@sinequa/components/metadata/metadata.scss";
+@import "../../../../node_modules/@sinequa/components/advanced/bootstrap/advanced.scss";
 
-$secondary-color: #6c757d;
+// default sinequa configuration
+@import 'themes/default';
+// allow cusomization
+@import 'themes/custom';
 
-html {
-    height: 100%;
-}
-
-body {
-    height: 100%;
-}
-
-a {
-    text-decoration: none;
-    color: #3434d6;
-}
-
-// large screens (> sm)
-@include media-breakpoint-up(sm) {
-
-    .sq-home-facet-bar {
-        min-height: 287px;
-    }
-
-    .card {
-        box-shadow: 0 5px 7px rgba(0,0,0,.08);
-    }
-}
-
-// Prevent width: 100% from .row on the drag & drop placeholder
-.row > .dragPlaceholder {
-    width: auto;
-}
-
-app-search-form {
-    box-shadow: 0px 0px 7px 2px rgba(0,0,0,.08);
-
-    .autocomplete-item {
-        small, i {
-            color: $secondary-color;
-        }
-    }
-}
-
-app-search nav {
-    box-shadow: 1px 3px 4px 0px rgba(0,0,0,.08);
-}
-
-
-// Results list
-
-sq-tabs {
-    .nav-item .count {
-        font-size: 0.9em;
-        color: $secondary-color;
-    }
-}
-
-sq-results-counter {
-    color: $secondary-color;
-    font-size: 0.85em;
-}
-
-sq-sort-selector button.btn {
-    padding: 3px 5px;
-    margin: -3px 0;
-    color: $secondary-color;
-    background-color: inherit;
-    font-size: 0.85em;
-    border: none;
-
-    & > div {
-        padding: 5px 0;
-    }
-}
-
-sq-result-selector label{
-    margin: 0 !important;
-    margin-left: 4px;
-}
-
-sq-sponsored-results {
-    .sponsored-item {
-        margin-top: 0.75em;
-    }
-    .sq-sponsored-link-view-summary {
-        color: $secondary-color;
-        font-size: 0.9em;
-    }
-}
-
-// Styling of the result items
-
-.result-list {
-    display: flex;
-    flex-wrap: wrap;
-
-    .record {
-
-        &:hover {
-            background-color: rgb(0,0,0,0.03);
-        }
-
-        &.selected {
-            background-color: rgb(0,0,0,0.05);
-        }
-
-        cursor: pointer;
-
-        sq-result-title {
-            display: block; // Added to force truncation of long titles with ellipsis
-            max-width: 100%;
-
-            .record .match-highlight {
-                font-weight: bold;
-                font-style: italic;
-            }
-        }
-
-        &.list-view {
-            padding: 0.5em 15px;
-            margin: 0 -15px;
-            width: calc(100% + 30px);
-
-            sq-result-thumbnail {
-                --thumbnail-max-width: 100px;
-                --thumbnail-max-height: 150px;
-                --thumbnail-border-radius: 3px;
-                & img {
-                    max-width: var(--thumbnail-max-width);
-                    max-height: var(--thumbnail-max-height);
-                    border-radius: var(--thumbnail-border-radius);
-                }
-            }
-        }
-
-        &.tile-view {
-            padding: 0.5em;
-            width: 50%;
-
-            sq-result-thumbnail img {
-                object-fit: cover;
-                object-position: center;
-                width: 100%;
-                height: 250px;
-                border-radius: 1em;
-            }
-        }
-    }
-}
-
-// Facets
-sq-facet-card.facet-preview {
-  .card-header {
-      sq-metadata {
-          color: $secondary-color;
-          font-size: 0.9em;
-      }
-  }
-
-  .sq-secondary-actions.position-absolute {
-      z-index: 5;
-  }
-
-  @media (pointer:fine) {
-      .sq-secondary-actions.on-preview-hover {
-          opacity: 0;
-          transition: opacity 250ms ease;
-      }
-      .card:hover {
-          .sq-secondary-actions.on-preview-hover {
-              opacity: 1;
-          }
-      }
-  }
-
-  @media (min-width: 1720px) {
-    .sq-secondary-actions.outside-if-space {
-      right: -4rem !important;
-    }
-
-  }
-}
-
-sq-feedback-menu {
-    button.btn{
-        border-radius: 19px;
-        width: 38px;
-        height: 38px;
-        padding-left: 10px;
-    }
-    .dropdown-toggle::after{
-        display: none;
-    }
-}
-
-// Reduce max height of facets in edit mode
-sq-facet-tree .list-group.list-group-flush, sq-facet-list .facet-results-scrollable, sq-facet-date > div {
-  max-height: calc(75vh - 250px);
-  overflow: auto;
-  transition: max-height .3s ease-in-out;
-}
-
-.uib-zone.edited {
-  sq-facet-tree .list-group.list-group-flush, sq-facet-list .facet-results-scrollable, sq-facet-date > div {
-    max-height: 100px;
-  }
-}
-
-
-// Flex basis classes
-.flex-basis-0 {
-    flex-basis: 0;
-}
-
-.flex-basis-auto {
-    flex-basis: auto;
-}
 
 @import 'dark-mode';

--- a/projects/vanilla/src/styles/dark-mode.scss
+++ b/projects/vanilla/src/styles/dark-mode.scss
@@ -17,6 +17,10 @@ body.dark {
 
     a:not(.btn):not(.badge) {
         color: #9bccff;
+        &:hover,
+        &:focus {
+          color: $dark-secondary;
+        }
     }
 
     .btn-link {
@@ -36,6 +40,10 @@ body.dark {
             background-color: $dark-background-highlight;
             border-color: $dark-borders;
         }
+    }
+
+    .navbar {
+        --navbar-bg: $dark-background;
     }
 
     .navbar-dark .navbar-nav .nav-link {
@@ -159,7 +167,7 @@ body.dark {
 
     app-search-form {
         box-shadow: 0px 0px 15px 4px $dark-background-highlight;
-        
+
         .list-group-item:not(.list-group-item-primary){
             .autocomplete-item {
                 small, i {
@@ -182,7 +190,9 @@ body.dark {
                 color: $dark-secondary;
             }
 
-            .nav-link.active, .nav-item.show .nav-link {
+            .nav-link.active, .nav-link.active:hover,
+            .nav-item.show
+            .nav-link {
                 color: $dark-color;
                 background-color: transparent;
                 border-color: $dark-borders $dark-borders $dark-background;
@@ -270,11 +280,11 @@ body.dark {
             border-color: $dark-borders;
         }
     }
-    
+
     sq-facet-mysearch {
         .sq-metadata-item {
             background-color: $dark-background;
-    
+
             &:hover {
                 background-color: $dark-background;
                 opacity: 0.8;

--- a/projects/vanilla/src/styles/themes/_custom.scss
+++ b/projects/vanilla/src/styles/themes/_custom.scss
@@ -1,0 +1,16 @@
+@import "prebuilt/buttons";
+@import "prebuilt/forms";
+@import "prebuilt/form-check";
+@import "prebuilt/card";
+@import "prebuilt/nav";
+
+body:not(.dark) {
+  background-color: var(--background-color, var(--bs-body-bg));
+  background-image: linear-gradient(var(--background-color), var(--gradient-color));
+  background-attachment: fixed;
+
+  // Need to override this class
+  .bg-primary {
+    background-color: var(--primary, var(--bs-primary)) !important;
+  }
+}

--- a/projects/vanilla/src/styles/themes/_cyberpunk.scss
+++ b/projects/vanilla/src/styles/themes/_cyberpunk.scss
@@ -1,0 +1,46 @@
+:root {
+  /* background color + gradent background color */
+  --background-color: #00ffd2;
+
+  /* primary color */
+  --primary-100: #ffccd8ff;
+  --primary-200: #ff99b1ff;
+  --primary-300: #ff003c;
+  --primary-400: #cc0030ff;
+  --primary-500: #990024ff;
+  --primary: var(--primary-300);
+  --primary-rgb: 255,0,60;
+
+  /* secondary color */
+  --secondary-100: #cce9e4ff;
+  --secondary-200: #99d3c8ff;
+  --secondary-300: #008f75;
+  --secondary-400: #00735eff;
+  --secondary-500: #005647ff;
+  --secondary: var(--secondary-300);
+  --secondary-rgb: 0,143,116;
+
+  /* branding color */
+  --brand-hue: 58;
+  --brand-saturation: 98%;
+  --brand-lightness: 49%;
+  --brand-100: #fefccdff;
+  --brand-200: #fdf99aff;
+  --brand-300: #f8ef02;
+  --brand-400: #c7c002ff;
+  --brand-500: #959002ff;
+  --brand: var(--brand-300);
+
+  /* text color settings */
+  /* darken */
+  --text1: hsl(var(--brand-hue) var(--brand-saturation) 10%);
+  /* medium */
+  --text2: hsl(var(--brand-hue) 30% 50%);
+  /* lighter */
+  --text3: hsl(var(--brand-hue), calc(80% - var(--brand-saturation)), calc(180% - var(--brand-lightness)) );
+  --text3-hover: hsl(var(--brand-hue), var(--brand-saturation), calc(160% - var(--brand-lightness)) );
+
+  /* text color used by the facet and the navbar */
+  --sq-text: var(--text1);
+  --sq-text-hover: var(--text2);
+}

--- a/projects/vanilla/src/styles/themes/_default.scss
+++ b/projects/vanilla/src/styles/themes/_default.scss
@@ -1,0 +1,208 @@
+/* default vanilla-search theme */
+$secondary-color: #6c757d;
+$navbar-bg: #f8f9fa;
+
+body {
+  height: 100%;
+}
+
+a {
+  text-decoration: none;
+  color: #3434d6;
+}
+
+// large screens (> sm)
+@include media-breakpoint-up(sm) {
+
+  .sq-home-facet-bar {
+      min-height: 287px;
+  }
+
+  .card {
+      box-shadow: 0 5px 7px rgba(0,0,0,.08);
+  }
+}
+
+// Prevent width: 100% from .row on the drag & drop placeholder
+.row > .dragPlaceholder {
+  width: auto;
+}
+
+app-search-form {
+  box-shadow: 0px 0px 7px 2px rgba(0,0,0,.08);
+
+  .autocomplete-item {
+      small, i {
+          color: $secondary-color;
+      }
+  }
+}
+
+app-search nav {
+  box-shadow: 1px 3px 4px 0px rgba(0,0,0,.08);
+}
+
+app-preview {
+  height: 100vh;
+  display: block;
+}
+
+// Results list
+
+sq-tabs {
+  .nav-item .count {
+      font-size: 0.9em;
+      color: $secondary-color;
+  }
+}
+
+sq-results-counter {
+  color: $secondary-color;
+  font-size: 0.85em;
+}
+
+sq-sort-selector button.btn {
+  padding: 3px 5px;
+  margin: -3px 0;
+  color: $secondary-color;
+  background-color: inherit;
+  font-size: 0.85em;
+  border: none;
+
+  & > div {
+      padding: 5px 0;
+  }
+}
+
+sq-result-selector label{
+  margin: 0 !important;
+  margin-left: 4px;
+}
+
+sq-sponsored-results {
+  .sponsored-item {
+      margin-top: 0.75em;
+  }
+  .sq-sponsored-link-view-summary {
+      color: $secondary-color;
+      font-size: 0.9em;
+  }
+}
+
+// Styling of the result items
+
+.result-list {
+  display: flex;
+  flex-wrap: wrap;
+
+  .record {
+
+      &:hover {
+          background-color: rgb(0,0,0,0.03);
+      }
+
+      &.selected {
+          background-color: rgb(0,0,0,0.05);
+      }
+
+      cursor: pointer;
+
+      sq-result-title {
+          display: block; // Added to force truncation of long titles with ellipsis
+          max-width: 100%;
+
+          .record .match-highlight {
+              font-weight: bold;
+              font-style: italic;
+          }
+      }
+
+      &.list-view {
+          padding: 0.5em 15px;
+          margin: 0 -15px;
+          width: calc(100% + 30px);
+
+          sq-result-thumbnail {
+              --thumbnail-max-width: 100px;
+              --thumbnail-max-height: 150px;
+              --thumbnail-border-radius: 3px;
+              & img {
+                  max-width: var(--thumbnail-max-width);
+                  max-height: var(--thumbnail-max-height);
+                  border-radius: var(--thumbnail-border-radius);
+              }
+          }
+      }
+
+      &.tile-view {
+          padding: 0.5em;
+          width: 50%;
+
+          sq-result-thumbnail img {
+              object-fit: cover;
+              object-position: center;
+              width: 100%;
+              height: 250px;
+              border-radius: 1em;
+          }
+      }
+  }
+}
+
+// Facets
+sq-facet-card.facet-preview {
+.card-header {
+    sq-metadata {
+        color: $secondary-color;
+        font-size: 0.9em;
+    }
+}
+
+.sq-secondary-actions.position-absolute {
+    z-index: 5;
+}
+
+@media (pointer:fine) {
+    .sq-secondary-actions.on-preview-hover {
+        opacity: 0;
+        transition: opacity 250ms ease;
+    }
+    .card:hover {
+        .sq-secondary-actions.on-preview-hover {
+            opacity: 1;
+        }
+    }
+}
+
+@media (min-width: 1720px) {
+  .sq-secondary-actions.outside-if-space {
+    right: -4rem !important;
+  }
+
+}
+}
+
+sq-feedback-menu {
+  button.btn{
+      border-radius: 19px;
+      width: 38px;
+      height: 38px;
+      padding-left: 10px;
+  }
+  .dropdown-toggle::after{
+      display: none;
+  }
+}
+
+// Reduce max height of facets in edit mode
+sq-facet-tree .list-group.list-group-flush, sq-facet-list .facet-results-scrollable, sq-facet-date > div {
+  max-height: calc(75vh - 250px);
+  overflow: auto;
+  transition: max-height .3s ease-in-out;
+}
+
+.uib-zone.edited {
+sq-facet-tree .list-group.list-group-flush, sq-facet-list .facet-results-scrollable, sq-facet-date > div {
+  max-height: 100px;
+}
+}

--- a/projects/vanilla/src/styles/themes/prebuilt/_buttons.scss
+++ b/projects/vanilla/src/styles/themes/prebuilt/_buttons.scss
@@ -1,0 +1,133 @@
+body:not(.dark) {
+  .btn {
+    color: var(--sq-btn-color, var(--bs-btn-color));
+    background-color: var(--sq-btn-bg, var(--bs-btn-bg));
+    border-color: var(--sq-btn-border-color, var(--bs-btn-border-color));
+
+    &:hover, &.active:hover {
+      color: var(--sq-btn-hover-color, var(--bs-btn-hover-color));
+      background-color: var(--sq-btn-hover-bg, var(--bs-btn-hover-bg));
+      border-color: var(--sq-btn-hover-border-color, var(--bs-btn-hover-border-color));
+    }
+
+    .btn-check + &:hover {
+      background-color: var(--sq-btn-bg, var(--bs-btn-bg));
+      border-color: var(--sq-btn-border-color, var(--bs-btn-border-color));
+    }
+
+    &:focus-visible {
+      background-color: var(--sq-btn-hover-bg ,var(--bs-btn-hover-bg));
+      border-color: var(--sq-btn-hover-border-color, var(--bs-btn-hover-border-color));
+      box-shadow: var(--sq-btn-focus-box-shadow);
+    }
+
+    .btn-check:focus-visible + & {
+      border-color: var(--sq-btn-hover-border-color ,var(--bs-btn-hover-border-color));
+      box-shadow: var(--sq-btn-focus-box-shadow);
+    }
+
+    .btn-check:checked + &,
+    :not(.btn-check) + &:active,
+    &:first-child:active,
+    &.active,
+    &.show {
+      color: var(--sq-btn-active-color, var(--bs-btn-active-color));
+      background-color: var(--sq-btn-active-bg, var(--bs-btn-active-bg));
+      border-color: var(--sq-btn-active-border-color, var(--bs-btn-active-border-color));
+      box-shadow: var(--sq-btn-focus-box-shadow);
+
+      &:focus-visible {
+        box-shadow: var(--sq-btn-focus-box-shadow);
+      }
+    }
+
+    &:disabled,
+    &.disabled,
+    fieldset:disabled & {
+      background-color: var(--sq-btn-disabled-bg, var(--bs-btn-disabled-bg));
+      border-color: var(--sq-btn-disabled-border-color, var(--bs-btn-disabled-border-color));
+    }
+  }
+
+  .btn-primary {
+    --sq-btn-bg: var(--primary);
+    --sq-btn-border-color: var(--primary);
+    --sq-btn-hover-bg: var(--primary-400);
+    --sq-btn-hover-border-color: var(--primary-500);
+    --sq-btn-disabled-bg: var(--primary-100);
+    --sq-btn-disabled-border-color: var(--primary-100);
+    --sq-btn-active-color: var(--bs-btn-active-color);
+    --sq-btn-active-bg: var(--primary-400);
+    --sq-btn-active-border-color: var(--primary-500, var(--bs-btn-active-border-color));
+    --sq-btn-focus-box-shadow: 0 0 0 .25rem rgb(var(--primary-rgb, var(--bs-btn-focus-shadow-rgb)), .5);
+  }
+
+  .btn-secondary {
+    --sq-btn-bg: var(--secondary);
+    --sq-btn-border-color: var(--secondary);
+    --sq-btn-hover-bg: var(--secondary-400);
+    --sq-btn-hover-border-color: var(--secondary-500);
+    --sq-btn-disabled-bg: var(--secondary-100);
+    --sq-btn-disabled-border-color: var(--secondary-100);
+    --sq-btn-active-color: var(--bs-btn-active-color);
+    --sq-btn-active-bg: var(--secondary-400);
+    --sq-btn-active-border-color: var(--secondary-500, var(--bs-btn-active-border-color));
+    --sq-btn-focus-box-shadow: 0 0 0 .25rem rgb(var(--secondary-rgb, var(--bs-btn-focus-shadow-rgb)), .5);
+  }
+
+  .btn-outline-primary {
+    --sq-btn-color: var(--primary);
+    --sq-btn-border-color: var(--primary);
+
+    --sq-btn-hover-bg: var(--primary-400);
+    --sq-btn-hover-border-color: var(--primary-500);
+
+    --sq-btn-disabled-color: var(--primary-200);
+    --sq-btn-disabled-border-color: var(--primary-200);
+
+    --sq-btn-active-bg: var(--primary-400);
+    --sq-btn-active-border-color: var(--primary-500);
+
+    --sq-btn-focus-box-shadow: 0 0 0 .25rem rgb(var(--primary-rgb, var(--bs-btn-focus-shadow-rgb)), .5);
+  }
+
+  .btn-outline-secondary {
+    --sq-btn-color: var(--secondary);
+    --sq-btn-border-color: var(--secondary);
+
+    --sq-btn-hover-color: var(--secondary-100);
+    --sq-btn-hover-bg: var(--secondary);
+    --sq-btn-hover-border-color: var(--secondary-400);
+
+    --sq-btn-disabled-color: var(--secondary-200);
+    --sq-btn-disabled-border-color: var(--secondary-200);
+
+    --sq-btn-active-bg: var(--secondary-400);
+    --sq-btn-active-border-color: var(--secondary-500);
+
+    --sq-btn-focus-box-shadow: 0 0 0 .25rem rgb(var(--secondary-rgb, var(--bs-btn-focus-shadow-rgb)), .5);
+  }
+
+  .btn-light {
+    --sq-btn-color: var(--sq-text);
+    --sq-btn-bg: var(--brand);
+    --sq-btn-border-color: var(--brand);
+
+    --sq-btn-hover-bg: var(--brand-200);
+    --sq-btn-hover-border-color: var(--brand-400);
+
+    --sq-btn-active-color: var(--sq-text);
+    --sq-btn-active-bg: var(--brand-400);
+    --sq-btn-active-border-color: var(--brand-500);
+
+    --sq-btn-disabled-color: var(--sq-text);
+    --sq-btn-disabled-bg: var(--brand-100);
+    --sq-btn-disabled-border-color: var(--brand-200);
+
+    --sq-btn-focus-box-shadow: 0 0 0 .25rem rgb(var(--brand-box-shadow-rgb, var(--bs-btn-focus-shadow)), .5);
+  }
+
+  .btn-close:focus {
+    box-shadow: 0 0 0 0.25rem rgb(var(--primary-rgb, 13 110 253), .25);
+  }
+}

--- a/projects/vanilla/src/styles/themes/prebuilt/_card.scss
+++ b/projects/vanilla/src/styles/themes/prebuilt/_card.scss
@@ -1,0 +1,12 @@
+body:not(.dark) {
+  .card {
+    --sq-card-cap-bg: var(--brand-300, var(--bs-card-cap-bg));
+    --sq-card-cap-color: var(--sq-text, var(--body-text-grey-1));
+    --sq-link-color: var(--text1, var(--body-text-grey-1));
+
+    .card-header {
+      color: var(--sq-card-cap-color);
+      background-color: var(--sq-card-cap-bg);
+    }
+  }
+}

--- a/projects/vanilla/src/styles/themes/prebuilt/_form-check.scss
+++ b/projects/vanilla/src/styles/themes/prebuilt/_form-check.scss
@@ -1,0 +1,15 @@
+body:not(.dark) {
+  .form-check-input {
+
+    &:checked {
+      background-color: var(--primary, var(--bs-primary));
+      border-color: var(--primary, var(--bs-primary));
+    }
+
+    &:focus {
+      border-color: var(--primary-400, var(--bs-primary));
+      --shadow-rgb: 13, 110, 253;
+      box-shadow: 0 0 0 .25rem rgb(var(--primary-rgb, var(--shadow-rgb)), .25);
+    }
+  }
+}

--- a/projects/vanilla/src/styles/themes/prebuilt/_forms.scss
+++ b/projects/vanilla/src/styles/themes/prebuilt/_forms.scss
@@ -1,0 +1,11 @@
+body:not(.dark) {
+
+  .form-select:focus,
+  .form-control:focus,
+  .form-control:focus-within {
+    --box-shadow-color-rgb: 13, 110, 253;
+    --border-color: #86b7fe;
+    border-color: var(--primary-200, var(--border-color)) !important;
+    box-shadow: 0 0 0 0.25rem rgb(var(--primary-rgb, var(--box-shadow-color-rgb)), .25) !important;
+  }
+}

--- a/projects/vanilla/src/styles/themes/prebuilt/_nav.scss
+++ b/projects/vanilla/src/styles/themes/prebuilt/_nav.scss
@@ -1,0 +1,48 @@
+body:not(.dark) {
+  nav {
+    &.navbar {
+      --navbar-bg: #f8f9fa;
+      background-color: var(--brand, var(--navbar-bg));
+
+      .nav-link {
+        color: var(--sq-text, rgba(0,0,0,0.55));
+
+        &:hover,
+        &:focus {
+          color: var(--sq-text-hover, rgba(0,0,0,0.7));
+        }
+      }
+    }
+  }
+
+
+  sq-tabs {
+    .nav-tabs {
+      color: var(--sq-text);
+      border-bottom-color: var(--brand, #dee2e6);
+
+      .nav-link {
+        &.active, &.active:hover {
+          --border-color: var(--brand) var(--brand) var(--background-color);
+          border-color: var(--border-color, #dee2e6 #dee2e6 #fff);
+        }
+        &:hover {
+          border-color: var(--brand, #dee2e6 #dee2e6);
+        }
+      }
+
+      .nav-link.active,
+      .show>.nav-link {
+        color: var(--sq-text, #495057);
+        background-color: var(--background-color, #fff);
+      }
+
+    }
+
+
+    .nav-item .count {
+      font-size: 0.9em;
+      color: var(--secondary, #6c757d);
+    }
+  }
+}


### PR DESCRIPTION
Allow custom theming (light only) - Dark theme is untouched.

* set **brand** color to set nav and card header color
* set **primary** color to set buttons color
* set **secondary** color to set secondary's buttons color
* navigation/card's header text can be overridden by the user (by default I use the third variant, because is color is defined by math computation depending of the saturation/brightness of the brand color choosen)


I use only 5 variants for each color:
* brand
* primary
* secondary

Range come from 100 to 500:
* 300 is the default value
* 100-200: are lighter than default (300)
* 400-500: are darker than default (300)

### app.scss
```css

// default sinequa configuration
@import 'themes/default';

// allow cusomization
@import 'themes/custom';

@import 'dark-mode';
```
* `themes/default` contains all css specific to vanilla theme
* `themes/custom` when present allow theme customization within the ui-builder's configurator
* `dark-mode` is the default vanilla-search dark mode theme. When a user select it, this theme override all settings even those from the customization

### theme customization colors

#### palette colors sample
![image](https://user-images.githubusercontent.com/818314/202163739-65c3dfcc-729b-4e63-ad5a-21875beee2cd.png)

* `primary` is used for the buttons

![image](https://user-images.githubusercontent.com/818314/202163284-5f6a5a71-7325-4ecf-8abd-a247f99b7c3c.png)

* `secondary` is used for other buttons (in modal usually)

![image](https://user-images.githubusercontent.com/818314/202163449-f038bdf0-dd8a-479c-8d10-3b55e0783032.png)

* `brand` is used in `navbar`, `facet` header and `tabs`
* `background` and `gradient` are used to configure the background color with or without gradient color

![image](https://user-images.githubusercontent.com/818314/202164643-6eb76d00-fc4c-42a0-be19-669c718396ba.png)

### Now, to customize the colors used in vanilla-search, a user can just update a bunch of css variables
Below an sample coming from `themes/cyberpunk.scss` file.
This variables can be overriden by the ui-builder configurator.

```css
:root {
  /* background color + gradent background color */
  --background-color: #00ffd2;

  /* primary color */
  --primary-100: #ffccd8ff;
  --primary-200: #ff99b1ff;
  --primary-300: #ff003c;
  --primary-400: #cc0030ff;
  --primary-500: #990024ff;
  --primary: var(--primary-300);
  --primary-rgb: 255,0,60;

  /* secondary color */
  --secondary-100: #cce9e4ff;
  --secondary-200: #99d3c8ff;
  --secondary-300: #008f75;
  --secondary-400: #00735eff;
  --secondary-500: #005647ff;
  --secondary: var(--secondary-300);

  /* branding color */
  --brand-hue: 58;
  --brand-saturation: 98%;
  --brand-lightness: 49%;
  --brand-100: #fefccdff;
  --brand-200: #fdf99aff;
  --brand-300: #f8ef02;
  --brand-400: #c7c002ff;
  --brand-500: #959002ff;
  --brand: var(--brand-300);

  /* text color settings */
  /* darken */
  --text1: hsl(var(--brand-hue) var(--brand-saturation) 10%);
  /* medium */
  --text2: hsl(var(--brand-hue) 30% 50%);
  /* lighter */
  --text3: hsl(var(--brand-hue), calc(80% - var(--brand-saturation)), calc(180% - var(--brand-lightness)) );
  --text3-hover: hsl(var(--brand-hue), var(--brand-saturation), calc(160% - var(--brand-lightness)) );

  /* text color used by the facet and the navbar */
  --sq-text: var(--text1);
  --sq-text-hover: var(--text2);
}
```