### PR TITLE
(fix) colors: metadata + toolbar buttons

### DIFF
--- a/projects/vanilla/src/app/preview/preview.component.html
+++ b/projects/vanilla/src/app/preview/preview.component.html
@@ -1,120 +1,183 @@
-<div class="d-flex flex-row align-items-stretch m-0 h-100">
-
-    <!-- Left panel (navigation, extracts and entities) -->
-    <div class="d-flex flex-column align-items-stretch border-right p-0"
-        [ngClass]="{'col-sm-5 col-md-4 col-lg-3': !collapsedPanel}"
-        *ngIf="ui.screenSizeIsGreater('xs')">
-
-        <!-- Navigation buttons/links (template below) -->
-        <ng-container *ngTemplateOutlet="nav"></ng-container>
-
-        <div class="border-top border-bottom p-2" *ngIf="!collapsedPanel">
-            <!-- Search form allowing the search preview -->
-            <sq-preview-search-form *ngIf="previewSearchable" [query]="query" (searchText)="searchText($event)"></sq-preview-search-form>
-
-            <!-- Page form allowing to go to an arbitrary page number (when the document is splitted)-->
-            <sq-preview-page-form [pageNumber]="previewData?.record?.$page" (gotopage)="gotoPage($event)"></sq-preview-page-form>
-
-            <!-- Navigation between the active sub panels -->
-            <ul class="nav nav-pills justify-content-center mb-1">
-                <li class="nav-item" *ngFor="let panel of subpanels">
-                    <a class="nav-link" href="#" [ngClass]="{active: subpanel === panel}" (click)="subpanel = panel; false">
-                        {{ ('msg#preview.'+panel) | sqMessage }}
-                    </a>
-                </li>
-            </ul>
-        </div>
-
-        <!-- Expanded panel different subpanels available -->
-        <!-- Extracts/Pages panel -->
-        <sq-preview-extracts-panel *ngIf="subpanel === 'extracts' && !pagesResults && !collapsedPanel"
-            class="d-flex flex-column flex-grow-1" [previewData]="previewData" [downloadUrl]="currentUrl"
-            [previewDocument]="previewDocument">
-        </sq-preview-extracts-panel>
-
-        <sq-preview-pages-panel *ngIf="subpanel === 'extracts' && pagesResults && !collapsedPanel"
-            class="overflow-auto"
-            [previewData]="previewData"
-            [previewDocument]="previewDocument"
-            [pages]="pagesResults"
-            (gotopage)="gotoPage($event)">
-        </sq-preview-pages-panel>
-
-        <div *ngIf="subpanel !== 'extracts' && !collapsedPanel" class="overflow-auto">
-
-            <!-- Legacy preview highlights -->
-            <sq-preview-highlights *ngIf="subpanel === 'highlights' && !!previewData" class="my-2"
-                [previewData]="previewData" [previewDocument]="previewDocument">
-            </sq-preview-highlights>
-
-            <!-- Entities panel -->
-            <div *ngIf="subpanel === 'entities'" class="p-2">
-                <sq-preview-entity-panel
-                    [previewData]="previewData"
-                    [previewDocument]="previewDocument"
-                    [startUnchecked]="entitiesStartUnchecked"
-                    (facetChecked)="entitiesChecked($event)">
-                </sq-preview-entity-panel>
-            </div>
-        </div>
-
-    </div>
-
-    <!-- Right panel (iframe with preview HTML) -->
-    <div class="d-flex flex-shrink-1 flex-grow-1 flex-column preview-bg">
-        <div *ngIf="previewData" class="p-2">
-            <h1>{{ previewData?.record.title }}</h1>
-            <!-- Link to the original document -->
-            <a title="Original document" target="_blank" href="{{previewData?.record.url1}}" (click)="openOriginalDoc()">{{previewData?.record.url1}}</a>
-        </div>
-        <sq-loading-bar [active]="loading"></sq-loading-bar>
-        <div class="flex-grow-1 flex-shrink-1 overflow-hidden">
-            <sq-preview-document-iframe
-                [scalingFactor]="scaleFactor"
-                [downloadUrl]="downloadUrl"
-                [sandbox]="sandbox"
-                (onPreviewReady)="onPreviewReady($event)"
-                (pageChange)="onPreviewPageChange($event)">
-
-                <!-- Tooltip injected in the preview -->
-                <sq-preview-tooltip #tooltip [previewDocument]="previewDocument" [previewData]="previewData" 
-                    [entityActions]="tooltipEntityActions" [selectedTextActions]="tooltipTextActions"
-                    [scalingFactor]="scaleFactor">
-                </sq-preview-tooltip>
-                <sq-preview-minimap #minimap [previewDocument]="previewDocument" [previewData]="previewData"></sq-preview-minimap>
-
-            </sq-preview-document-iframe>
-        </div>
-    </div>
-
-</div>
-
-<ng-template #nav>
-    <div class="align-self-stretch d-flex justify-content-between align-items-center p-1" [ngClass]="{'flex-column flex-grow-1': collapsedPanel}">
-        <div [ngClass]="{'btn-group': !collapsedPanel, 'btn-group-vertical':collapsedPanel}">
-            
-            <!-- Toggles the left panel collapsed/expanded state -->
-            <button class="btn btn-lg btn-primary" [placement]="leftPanelTooltipPlacement()" sqTooltip="Expand" (click)="collapsedPanel = !collapsedPanel">
-                <i class="fas fa-bars"></i>
-            </button>
-
+<div class="nav-wrapper d-block d-lg-none">
+    <nav class="navbar navbar-expand-sm d-flex justify-content-between py-2 py-sm-3"
+        [ngClass]="{'navbar-light bg-light': !isDark(), 'navbar-dark bg-dark': isDark()}">
+        <div class="d-flex flex-row">
             <!-- Back button (go back to /search route) -->
-            <button class="btn btn-lg btn-light" [placement]="leftPanelTooltipPlacement()" sqTooltip="Back" (click)="back()" *ngIf="showBackButton">
+            <button class="btn btn-link btn-lg" [sqTooltip]="'msg#preview.back' | sqMessage" (click)="back()"
+                *ngIf="showBackButton">
                 <i class="fas fa-arrow-left"></i>
             </button>
-
-            <!-- Home page link -->
-            <a [routerLink]="[homeRoute]" class="btn btn-lg btn-light" [placement]="leftPanelTooltipPlacement()" sqTooltip="Home" *ngIf="homeRoute">
-                <i class="fas fa-home"></i>
+            <!-- PDF version link -->
+            <a [href]="previewData?.record?.pdfUrl" target="_blank" class="btn btn-link btn-lg me-2"
+                [sqTooltip]="'msg#preview.downloadPdf' | sqMessage" (click)="notifyPdf()"
+                *ngIf="previewData?.record?.pdfUrl">
+                <i class="fas fa-file-pdf"></i>
             </a>
-
-            <button class="btn btn-lg btn-light" [placement]="leftPanelTooltipPlacement()" sqTooltip="{{'msg#facet.preview.minimize' | sqMessage }}" (click)="decreaseScaleFactor()" [disabled]="shouldDisableMinimize()">
-                <i class="fas fa-search-minus"></i>
-            </button>
-            <button class="btn btn-lg btn-light" [placement]="leftPanelTooltipPlacement()" sqTooltip="{{'msg#facet.preview.maximize' | sqMessage }}" (click)="increaseScaleFactor()">
-                <i class="fas fa-search-plus"></i>
+            <!-- Application logo -->
+            <a [routerLink]="['/home']" title="Home" class="d-flex">
+                <img id="logo" src="assets/sinequa-logo-light-lg.png" alt="sinequa logo" *ngIf="!isDark()">
+                <img id="logo" src="assets/sinequa-logo-dark-lg.png" alt="sinequa logo" *ngIf="isDark()">
+            </a>
+        </div>
+        <div>
+            <!-- Left panel expand button (mobile/tablet only) -->
+            <button class="btn btn-link btn-lg"
+                [sqTooltip]="(collapsedPanel ? 'msg#preview.expand' : 'msg#preview.collapse') | sqMessage"
+                (click)="collapsedPanel = !collapsedPanel">
+                <i class="fas {{collapsedPanel ? 'fa-bars' : 'fa-times'}}"></i>
             </button>
         </div>
-        <img id="logo" src="{{ isDark() ? 'assets/sinequa-logo-dark-sm.png' : 'assets/sinequa-logo-light-sm.png'}}" alt="Sinequa logo" title="Sinequa">
+    </nav>
+</div>
+
+<div class="preview-container">
+
+    <div class="row preview-content d-flex">
+
+        <!-- Left panel (navigation, extracts and entities) -->
+        <div class="side-menu h-100 d-flex flex-column justify-content-between"
+            *ngIf="ui.screenSizeIsGreaterOrEqual('lg') || !collapsedPanel"
+            [ngClass]="{'col-xs-12 col-sm-6 col-md-5 col-lg-3': !collapsedPanel, 'w-auto': collapsedPanel}">
+            <div class="side-menu-header d-flex justify-content-between px-2 px-lg-4 pt-2 pt-lg-4"
+                *ngIf="ui.screenSizeIsGreaterOrEqual('lg')" [ngClass]="{'collapsed': collapsedPanel}">
+                <!-- Application logo at first position (template below)-->
+                <ng-container *ngIf="(!collapsedPanel || !ui.screenSizeIsGreaterOrEqual('lg')) else logo">
+                </ng-container>
+
+                <div>
+                    <!-- Back button (go back to /search route) -->
+                    <button class="btn btn-link btn-lg" [sqTooltip]="'msg#preview.back' | sqMessage" (click)="back()"
+                        *ngIf="showBackButton" [ngClass]="{'mt-2': collapsedPanel}">
+                        <i class="fas fa-arrow-left"></i>
+                    </button>
+
+                    <!-- PDF version link -->
+                    <a [href]="previewData?.record?.pdfUrl" target="_blank" class="btn btn-link btn-lg my-1"
+                        [sqTooltip]="'msg#preview.downloadPdf' | sqMessage" (click)="notifyPdf()"
+                        *ngIf="previewData?.record?.pdfUrl">
+                        <i class="fas fa-file-pdf"></i>
+                    </a>
+                </div>
+
+                <ng-container *ngIf="(collapsedPanel && ui.screenSizeIsGreaterOrEqual('lg')) else logo"></ng-container>
+
+                <!-- Toggles the left panel collapsed/expanded state -->
+                <button class="btn btn-link btn-lg"
+                    [sqTooltip]="(collapsedPanel ? 'msg#preview.expand' : 'msg#preview.collapse') | sqMessage"
+                    (click)="collapsedPanel = !collapsedPanel">
+                    <i class="fas {{collapsedPanel ? 'fa-bars' : 'fa-times'}}"></i>
+                </button>
+
+            </div>
+
+            <div class="flex-grow-1 d-flex flex-column">
+                <ng-container *ngIf="!loading && !collapsedPanel" [ngSwitch]="subpanel">
+                    <div class="pt-2 pt-lg-4 px-2 px-lg-4">
+                        <!-- Search form allowing the search preview -->
+                        <sq-preview-search-form *ngIf="previewSearchable" [query]="query"
+                            (searchText)="searchText($event)">
+                        </sq-preview-search-form>
+
+                        <!-- Page form allowing to go to an arbitrary page number (when the document is splitted)-->
+                        <sq-preview-page-form [pageNumber]="previewData?.record?.$page" (gotopage)="gotoPage($event)">
+                        </sq-preview-page-form>
+
+                    </div>
+
+                    <!-- Navigation between the active sub panels -->
+                    <sq-tabs [customtabs]="tabs" [showCounts]="false" [selectedTab]="subpanel"
+                        class="d-block mb-2 mb-lg-3 pt-2 pt-lg-4 px-2 px-lg-4" (events)="openPanel($event)">
+                    </sq-tabs>
+
+                    <ng-container *ngSwitchCase="'extracts'">
+
+                        <!-- Expanded panel different subpanels available -->
+                        <!-- Extracts/Pages panel -->
+                        <sq-preview-extracts-panel *ngIf="!pagesResults" class="flex-scroll" [extractsNumber]="10"
+                            [previewData]="previewData" [downloadUrl]="currentUrl" [previewDocument]="previewDocument">
+                        </sq-preview-extracts-panel>
+
+                        <sq-preview-pages-panel *ngIf="pagesResults" class="flex-scroll" [previewData]="previewData"
+                            [previewDocument]="previewDocument" [pages]="pagesResults" (gotopage)="gotoPage($event)">
+                        </sq-preview-pages-panel>
+
+                    </ng-container>
+
+                    <!-- Neural Search preview passages -->
+                    <ng-container *ngSwitchCase="'passages'">
+                        <sq-preview-extracts-panel class="flex-scroll" [downloadUrl]="currentUrl"
+                            [previewData]="previewData" [previewDocument]="previewDocument" [extractsNumber]="10"
+                            type="matchingpassages">
+                        </sq-preview-extracts-panel>
+                    </ng-container>
+
+                    <!-- Entities panel -->
+                    <ng-container *ngSwitchCase="'entities'">
+                        <sq-preview-entity-panel class="flex-scroll px-2" [previewData]="previewData"
+                            [previewDocument]="previewDocument" [startUnchecked]="entitiesStartUnchecked"
+                            (facetChecked)="entitiesChecked($event)">
+                        </sq-preview-entity-panel>
+                    </ng-container>
+
+                    <!-- Legacy preview highlights -->
+                    <ng-container *ngSwitchCase="'highlights'">
+                        <sq-preview-highlights class="d-flex flex-column flex-grow-1 my-2" [previewData]="previewData"
+                            [previewDocument]="previewDocument">
+                        </sq-preview-highlights>
+                    </ng-container>
+
+                </ng-container>
+            </div>
+
+        </div>
+
+        <!-- Right panel (iframe with preview HTML) -->
+        <sq-facet-card [collapsible]="false" class="preview m-0" [actions]="actions" [actionsSize]="'md'"
+            [ngClass]="{'d-none d-sm-block col-sm-6 col-md-7 col-lg-9': !collapsedPanel}">
+            <ng-template #headerTpl>
+                <div class="text-truncate flex-grow-1 py-2">
+                    <div class="preview-title text-truncate">{{previewData?.record.title}}</div>
+                    <!-- Link to the original document -->
+                    <a *ngIf="getOriginalDocUrl() as url" [sqTooltip]="'msg#preview.original' | sqMessage"
+                        target="_blank" href="{{url}}" (click)="notifyOriginalDoc()" class="mt-1">
+                        {{url}}
+                    </a>
+                </div>
+            </ng-template>
+
+                <sq-loading-bar [active]="loading"></sq-loading-bar>
+                <sq-preview-document-iframe [scalingFactor]="scaleFactor" [downloadUrl]="downloadUrl"
+                    [sandbox]="sandbox" (onPreviewReady)="onPreviewReady($event)"
+                    (pageChange)="onPreviewPageChange($event)">
+
+                    <!-- Tooltip injected in the preview -->
+                    <sq-preview-tooltip #tooltip [previewDocument]="previewDocument" [previewData]="previewData"
+                        [entityActions]="tooltipEntityActions" [selectedTextActions]="tooltipTextActions"
+                        [scalingFactor]="scaleFactor">
+                    </sq-preview-tooltip>
+
+                    <sq-preview-minimap #minimap [previewDocument]="previewDocument" [previewData]="previewData"
+                        [type]="showHighlights ? minimapType : ''" [passage]="previewDocument?.passageHighlightParams">
+                    </sq-preview-minimap>
+
+                    <sq-passage-highlight #passageHighlight
+                        [params]="previewDocument?.passageHighlightParams"></sq-passage-highlight>
+
+                </sq-preview-document-iframe>
+
+        </sq-facet-card>
+
     </div>
-</ng-template>
+
+    <ng-template #logo>
+        <a [routerLink]="['/home']" title="Home" class="d-flex">
+            <img id="logo" src="assets/sinequa-logo-light-lg.png" alt="sinequa logo"
+                *ngIf="(!collapsedPanel || ui.screenSizeIsLess('lg')) && !isDark()">
+            <img id="logo" src="assets/sinequa-logo-dark-lg.png" alt="sinequa logo"
+                *ngIf="(!collapsedPanel || ui.screenSizeIsLess('lg')) && isDark()">
+            <img id="logo" src="assets/sinequa-logo-light-sm.png" alt="sinequa logo"
+                *ngIf="collapsedPanel && ui.screenSizeIsGreaterOrEqual('lg') && !isDark()">
+            <img id="logo" src="assets/sinequa-logo-dark-sm.png" alt="sinequa logo"
+                *ngIf="collapsedPanel && ui.screenSizeIsGreaterOrEqual('lg') && isDark()">
+        </a>
+    </ng-template>

--- a/projects/vanilla/src/app/preview/preview.component.scss
+++ b/projects/vanilla/src/app/preview/preview.component.scss
@@ -1,12 +1,108 @@
-.overflow-y-scroll {
-    overflow-y: auto;
+@import "bootstrap/scss/_functions";
+@import "bootstrap/scss/_variables";
+@import "bootstrap/scss/_mixins";
+
+@import "@sinequa/components/theme/breakpoints";
+
+:host ::ng-deep {
+  sq-facet-card .card {
+    height: 100%;
+
+    sq-collapse {
+      flex: 1;
+
+      .sq-collapse {
+        height: 100%;
+      }
+    }
+  }
 }
 
-.preview-bg {
-    background-color: #efefef;
+nav {
+  padding-left: .5rem;
+  padding-right: .5rem;
+  box-shadow: 0 0 1.25rem 0 rgba(0, 0, 0, .15);
+  z-index: 99;
 }
 
-:host-context(.dark)
-.preview-bg {
-  background-color: black;
+.preview-container {
+  height: calc(100% - 3.5rem);
+  width: 100%;
+
+  @include media-breakpoint-up(sm) {
+    height: calc(100% - 4.5rem);
+  }
+
+  @include media-breakpoint-up(lg) {
+    height: 100%;
+  }
+}
+
+.preview {
+  flex: 1;
+
+  @include media-breakpoint-up(lg) {
+    padding: 1.25rem 2.5rem 1.25rem 1.25rem;
+  }
+}
+
+.preview-content {
+  --bs-gutter-x: 0;
+  --bs-gutter-y: 0;
+  height: 100%;
+  background-color: #efefef;
+}
+
+.side-menu {
+  padding-right: 0;
+  background-color: white;
+  z-index: 9;
+  -webkit-animation: slide 0.5s forwards;
+  -webkit-animation-delay: 2s;
+  animation: slide 0.5s forwards;
+  animation-delay: 2s;
+  flex-direction: column;
+
+  .side-menu-header {
+    &.collapsed {
+      @include media-breakpoint-up(lg) {
+        flex-direction: column;
+      }
+    }
+  }
+
+  sq-tabs {
+    z-index: 20;
+  }
+
+  .card {
+    flex: 1;
+  }
+}
+
+nav img,
+.side-menu img {
+  height: 2.5rem;
+  display: block;
+  margin: auto;
+}
+
+.flex-scroll {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  height: 0;
+}
+
+.preview-title {
+  font-size: 1.25rem;
+}
+
+:host-context(.dark) {
+  .preview-content {
+    background-color: black;
+  }
+
+  .side-menu {
+    background-color: #1c1e21;
+  }
 }

--- a/projects/vanilla/src/app/preview/preview.component.ts
+++ b/projects/vanilla/src/app/preview/preview.component.ts
@@ -1,13 +1,12 @@
-import { Component, OnInit, OnChanges, Input, Optional, Inject, InjectionToken, OnDestroy, ChangeDetectorRef, NgZone} from '@angular/core';
+import { Component, OnInit, OnChanges, Input, Optional, Inject, InjectionToken, OnDestroy, ChangeDetectorRef, NgZone } from '@angular/core';
 import { Title } from '@angular/platform-browser';
 import { Location } from "@angular/common";
 import { ActivatedRoute, Router, NavigationEnd, RouterEvent } from '@angular/router';
-import { Subscription } from 'rxjs';
-import { filter} from 'rxjs/operators';
+import { Subscription, filter } from 'rxjs';
 
 import { LoginService } from '@sinequa/core/login';
-import { PreviewData, Results } from '@sinequa/core/web-services';
-import { Query } from '@sinequa/core/app-utils';
+import { AuditEventType, PreviewData, Results, Tab } from '@sinequa/core/web-services';
+import { AppService, Query } from '@sinequa/core/app-utils';
 import { Action } from '@sinequa/components/action';
 import { PreviewService, PreviewDocument } from '@sinequa/components/preview';
 import { SearchService } from '@sinequa/components/search';
@@ -34,8 +33,8 @@ export interface PreviewInput {
 export interface EntitiesState {
   count: number;
   sortFreq: boolean;
-  hidden: Map<string,boolean>;
-  nav: Map<string,number>;
+  hidden: Map<string, boolean>;
+  nav: Map<string, number>;
   category: string;
 }
 
@@ -64,12 +63,14 @@ export class PreviewComponent implements OnInit, OnChanges, OnDestroy {
   previewDocument?: PreviewDocument;
 
   // State of the preview
-  collapsedPanel= true;
+  collapsedPanel = false;
   homeRoute = "/home";
   showBackButton = true;
-  subpanels = ["extracts", "entities"];
-  subpanel = 'extracts';
+  subpanels = ["entities"];
+  subpanel = 'entities';
   previewSearchable = true;
+  minimapType = "extractslocations";
+  tabs: Tab[];
 
   // Page management for splitted documents
   pagesResults: Results;
@@ -81,6 +82,14 @@ export class PreviewComponent implements OnInit, OnChanges, OnDestroy {
   // Preview Tooltip
   tooltipEntityActions: Action[] = [];
   tooltipTextActions: Action[] = [];
+
+  // Preview actions
+  private minimizeAction: Action;
+  private maximizeAction: Action;
+  private displayHighlightsAction: Action;
+  private highlightType: string;
+  actions: Action[] = [];
+  showHighlights: boolean;
 
   private readonly scaleFactorThreshold = 0.2;
   scaleFactor = 1.0;
@@ -97,11 +106,13 @@ export class PreviewComponent implements OnInit, OnChanges, OnDestroy {
     protected intlService: IntlService,
     protected previewService: PreviewService,
     protected searchService: SearchService,
+    public appService: AppService,
     public prefs: UserPreferences,
     public ui: UIService,
     protected activatedRoute: ActivatedRoute,
     private zone: NgZone
-    ) {
+  ) {
+    this.showHighlights = this.prefs.get("preview-highlights") || true;
 
     // If the page is refreshed login needs to happen again, then we can get the preview data
     this.loginSubscription = this.loginService.events.subscribe({
@@ -117,16 +128,16 @@ export class PreviewComponent implements OnInit, OnChanges, OnDestroy {
       .pipe(
         filter(event => event instanceof RouterEvent && event.url !== this.homeRoute)
       ).subscribe({
-      next: (event) => {
-        if (event instanceof NavigationEnd) {
-          this.getPreviewDataFromUrl();
+        next: (event) => {
+          if (event instanceof NavigationEnd) {
+            this.getPreviewDataFromUrl();
+          }
         }
-      }
-    });
+      });
 
     // In case the component is loaded in a modal
-    if(previewInput){
-      if(previewInput.config){
+    if (previewInput) {
+      if (previewInput.config) {
         previewConfig = previewInput.config;
       }
       this.id = previewInput.id;
@@ -134,7 +145,7 @@ export class PreviewComponent implements OnInit, OnChanges, OnDestroy {
     }
 
     // Configuration may be injected by the root app (or as above by the modal)
-    if(previewConfig){
+    if (previewConfig) {
       this.previewConfig = previewConfig;
     }
 
@@ -147,13 +158,48 @@ export class PreviewComponent implements OnInit, OnChanges, OnDestroy {
           this.query.text = event['text'].slice(0, 50);
           this.router.navigate([], {
             relativeTo: this.route,
-            queryParams: {query: this.query.toJsonForQueryString()},
+            queryParams: { query: this.query.toJsonForQueryString() },
             queryParamsHandling: 'merge',
             state: {}
           });
         }
       }
     }));
+
+    this.displayHighlightsAction = new Action({
+      icon: "fas fa-fw fa-highlighter",
+      title: "msg#facet.preview.toggleHighlight",
+      action: () => {
+        this.showHighlights = !this.showHighlights;
+        this.prefs.set("preview-highlights", this.showHighlights);
+        this.updateHighlights(this.showHighlights ? this.highlightType : undefined);
+        if (this.showHighlights && this.highlightType === "matchingpassages") {
+          this.previewDocument?.highlightPassage();
+        }
+      }
+    });
+
+    this.maximizeAction = new Action({
+      icon: "fas fa-fw fa-search-plus",
+      title: "msg#facet.preview.maximize",
+      action: () => {
+        this.scaleFactor = this.scaleFactor + this.scaleFactorThreshold;
+      }
+    });
+
+    this.minimizeAction = new Action({
+      icon: "fas fa-fw fa-search-minus",
+      title: "msg#facet.preview.minimize",
+      disabled: this.scaleFactor <= 0.1,
+      action: () => {
+        this.scaleFactor = Math.round(Math.max(0.1, this.scaleFactor - this.scaleFactorThreshold) * 100) / 100;
+      },
+      updater: (action) => {
+        action.disabled = this.scaleFactor <= 0.1;
+      }
+    });
+
+    this.actions.push(this.displayHighlightsAction, this.minimizeAction, this.maximizeAction);
 
     titleService.setTitle(this.intlService.formatMessage("msg#preview.pageTitle"));
 
@@ -173,33 +219,38 @@ export class PreviewComponent implements OnInit, OnChanges, OnDestroy {
    */
   ngOnInit() {
 
-    if(!this.id || !this.query) { // do nothing if the parameters are already here
+    if (!this.id || !this.query) { // do nothing if the parameters are already here
       this.getPreviewDataFromUrl();
     }
 
-    if(this.previewConfig){
-      if(this.previewConfig.initialCollapsedPanel !== undefined){
+    if (this.previewConfig) {
+      if (this.previewConfig.initialCollapsedPanel !== undefined) {
         this.collapsedPanel = this.previewConfig.initialCollapsedPanel;
       }
-      if(this.previewConfig.homeRoute !== undefined){
+      if (this.previewConfig.homeRoute !== undefined) {
         this.homeRoute = this.previewConfig.homeRoute;
       }
-      if(this.previewConfig.showBackButton !== undefined){
+      if (this.previewConfig.showBackButton !== undefined) {
         this.showBackButton = this.previewConfig.showBackButton;
       }
-      if(this.previewConfig.subpanels !== undefined){
+      if (this.previewConfig.subpanels !== undefined) {
         this.subpanels = this.previewConfig.subpanels;
+        this.tabs = this.subpanels.map(panel => this.getTab(panel));
       }
-      if(this.previewConfig.defaultSubpanel !== undefined){
+      if (this.previewConfig.defaultSubpanel !== undefined) {
         this.subpanel = this.previewConfig.defaultSubpanel;
       }
-      if(this.previewConfig.previewSearchable !== undefined){
+      if (this.previewConfig.previewSearchable !== undefined) {
         this.previewSearchable = this.previewConfig.previewSearchable;
       }
     }
+
+    if (!this.previewConfig || this.previewConfig.initialCollapsedPanel === undefined) {
+      this.collapsedPanel = this.ui.screenSizeIsLessOrEqual('xs');
+    }
   }
 
-  ngOnDestroy(){
+  ngOnDestroy() {
     this.loginSubscription.unsubscribe();
     this.routerSubscription.unsubscribe();
   }
@@ -219,21 +270,36 @@ export class PreviewComponent implements OnInit, OnChanges, OnDestroy {
    * Performs a call to the preview service. Update the search form with the searched query text (page refresh or navigation)
    */
   private getPreviewData() {
-    if(!!this.id && !!this.query && this.loginService.complete) {
+    if (!!this.id && !!this.query && this.loginService.complete) {
       this.previewService.getPreviewData(this.id, this.query).subscribe(
         previewData => {
           this.previewData = previewData;
           const url = previewData?.documentCachedContentUrl;
+          this.subpanels = ["entities"];
+          this.tabs = [
+            this.getTab('entities')
+          ];
+          if (previewData.highlightsPerCategory['matchingpassages']?.values.length) {
+            this.subpanels.unshift("passages");
+            this.tabs.unshift(this.getTab('passages'));
+            this.subpanel = "passages";
+            this.minimapType = "extractslocations";
+          } else {
+            this.subpanels.unshift("extracts");
+            this.tabs.unshift(this.getTab('extracts'));
+            this.subpanel = "extracts";
+            this.minimapType = "extractslocations";
+          }
           // Manage splitted documents
           const pageNumber = this.previewService.getPageNumber(previewData.record);
-          if(pageNumber) {
+          if (pageNumber) {
             this.previewService.fetchPages(previewData.record.containerid!, this.query!)
               .subscribe(results => this.pagesResults = results);
           }
           this.currentUrl = url;
           this.downloadUrl = url ? this.previewService.makeDownloadUrl(url) : undefined;
-          this.sandbox = ["xlsx","xls"].includes(previewData.record.docformat) ? null : undefined;
-          this.titleService.setTitle(this.intlService.formatMessage("msg#preview.pageTitle", {title: previewData?.record?.title || ""}));
+          this.sandbox = ["xlsx", "xls"].includes(previewData.record.docformat) ? null : undefined;
+          this.titleService.setTitle(this.intlService.formatMessage("msg#preview.pageTitle", { title: previewData?.record?.title || "" }));
           this.loading = true;
         }
       );
@@ -244,20 +310,70 @@ export class PreviewComponent implements OnInit, OnChanges, OnDestroy {
    * Called when the HTML of the preview finishes loading in the iframe
    * @param previewDocument
    */
-  onPreviewReady(previewDocument: PreviewDocument){
+  onPreviewReady(previewDocument: PreviewDocument) {
     if (this.previewData) {
       this.loading = false;
       // uses preferences to uncheck highlighted entities
       const uncheckedEntities = this.entitiesStartUnchecked;
       Object.keys(uncheckedEntities)
-        .map(key => ({entity: key, value: uncheckedEntities[key]}))
+        .map(key => ({ entity: key, value: uncheckedEntities[key] }))
         .filter(item => item.value === true)
         .map(item => previewDocument.toggleHighlight(item.entity, false));
 
       this.previewDocument = previewDocument;
-      const extracts = this.previewService.getExtracts(this.previewData);
-      const mostRelevantExtract = extracts[0]?.textIndex || 0;
-      this.previewDocument.selectHighlight("extractslocations", mostRelevantExtract); // Scroll to most relevant extract
+      if (!this.highlightMostRelevant(this.previewData, this.previewDocument, "matchingpassages")) {
+        this.highlightMostRelevant(this.previewData, this.previewDocument, "extractslocations");
+      }
+    }
+  }
+
+  highlightMostRelevant(previewData: PreviewData, previewDocument: PreviewDocument, type: string): boolean {
+    const extracts = this.previewService.getExtracts(previewData, undefined, type);
+    this.updateHighlights(type);
+    if (extracts[0]) {
+      const mostRelevantExtract = extracts[0].textIndex;
+      previewDocument.selectHighlight(type, mostRelevantExtract); // Scroll to most relevant extract
+      return true;
+    }
+    return false;
+  }
+
+  updateHighlights(type?: string) {
+    if (this.previewData) {
+      if (!type) {
+        this.previewDocument?.filterHighlights([]);
+      } else {
+        this.highlightType = type;
+        const highlights = Object.keys(this.previewData.highlightsPerCategory)
+          .filter(h => (type === "matchingpassages" && (h === "matchingpassages" || h === "extractslocations" || h === "matchlocations"))
+            || (type === "extractslocations" && (h === "extractslocations" || h === "matchlocations"))
+            || (type === 'entities' && h !== "matchingpassages" && h !== "extractslocations"));
+        this.previewDocument?.filterHighlights(highlights);
+      }
+    }
+  }
+
+  openPanel(tab: Tab) {
+    const panel = tab.value;
+    this.subpanel = panel;
+    // Change the type of extract highlighted by the minimap in function of the current tab
+    if (panel === "passages") {
+      this.minimapType = "extractslocations";
+      if (this.previewData && this.previewDocument) {
+        this.highlightMostRelevant(this.previewData, this.previewDocument, "matchingpassages")
+      }
+    } else {
+      this.previewDocument?.clearPassageHighlight();
+    }
+    if (panel === "extracts") {
+      this.minimapType = "extractslocations";
+      if (this.previewData && this.previewDocument) {
+        this.highlightMostRelevant(this.previewData, this.previewDocument, "extractslocations")
+      }
+    }
+    if (panel === 'entities') {
+      this.minimapType = "none";
+      this.updateHighlights('entities');
     }
   }
 
@@ -276,16 +392,30 @@ export class PreviewComponent implements OnInit, OnChanges, OnDestroy {
   /**
    * Back button (navigating back to search)
    */
-  back(){
+  back() {
     this._location.back();
+  }
+
+  /**
+   * @returns URL of the original document, if any
+   */
+  getOriginalDocUrl(): string | undefined {
+    return this.previewData?.record.url1 || this.previewData?.record.originalUrl;
   }
 
   /**
    * Notification for the audit service
    */
-  openOriginalDoc(){
+  notifyOriginalDoc() {
     if (this.previewData) {
-      this.searchService.notifyOpenOriginalDocument(this.previewData.record);
+      const type = this.previewData?.record.url1 ? AuditEventType.Doc_Url1 : AuditEventType.Doc_CacheOriginal;
+      this.searchService.notifyOpenOriginalDocument(this.previewData.record, undefined, type);
+    }
+  }
+
+  notifyPdf() {
+    if (this.previewData) {
+      this.searchService.notifyOpenOriginalDocument(this.previewData.record, undefined, AuditEventType.Doc_CachePdf);
     }
   }
 
@@ -295,7 +425,7 @@ export class PreviewComponent implements OnInit, OnChanges, OnDestroy {
    */
   gotoPage(page: number) {
     const containerid = this.previewData?.record.containerid;
-    if(containerid) {
+    if (containerid) {
       const id = `${containerid}/#${page}#`;
 
       // we needs surround router.navigate() as we navigate outside Angular
@@ -315,11 +445,11 @@ export class PreviewComponent implements OnInit, OnChanges, OnDestroy {
    * @param text
    */
   searchText(text: string) {
-    if(this.query && this.query.text !== text) {
+    if (this.query && this.query.text !== text) {
       this.query.text = text;
       this.router.navigate([], {
         relativeTo: this.route,
-        queryParams: {query: this.query.toJsonForQueryString()},
+        queryParams: { query: this.query.toJsonForQueryString() },
         queryParamsHandling: 'merge',
         state: {}
       });
@@ -338,31 +468,22 @@ export class PreviewComponent implements OnInit, OnChanges, OnDestroy {
   /**
    * Entity facets state
    */
-  get entitiesStartUnchecked(): {[entity: string]: boolean} {
+  get entitiesStartUnchecked(): { [entity: string]: boolean } {
     return this.prefs.get("preview-entities-checked") || {};
   }
 
-  entitiesChecked(event: {entity: string, checked: boolean}) {
+  entitiesChecked(event: { entity: string, checked: boolean }) {
     const startUnchecked = this.entitiesStartUnchecked;
     startUnchecked[event.entity] = !event.checked;
     this.prefs.set("preview-entities-checked", startUnchecked);
   }
 
-  increaseScaleFactor() {
-    this.scaleFactor = this.scaleFactor + this.scaleFactorThreshold;
-    return false;
-  }
-
-  decreaseScaleFactor() {
-    this.scaleFactor = Math.round(Math.max(0.1, this.scaleFactor - this.scaleFactorThreshold) * 100) / 100;
-    return false;
-  }
-
-  shouldDisableMinimize() {
-    return this.scaleFactor <= 0.1;
-  }
-
-  leftPanelTooltipPlacement() {
-    return this.collapsedPanel ? 'right' : 'bottom'
+  private getTab(panel: string): Tab {
+    return {
+      name: panel,
+      display: `msg#preview.${panel}`,
+      value: panel,
+      count: 1
+    }
   }
 }

--- a/projects/vanilla/src/app/toolbar/toolbar.component.html
+++ b/projects/vanilla/src/app/toolbar/toolbar.component.html
@@ -7,7 +7,7 @@
         <button *ngIf="exportInProgress" class="btn btn-primary" disabled>
             <span class="fas fa-fw fa-spinner fa-spin"></span>
         </button>
-        <ul class="dropdown-menu">
+        <ul class="dropdown-menu dropdown-menu-end">
             <li>
                 <a class="dropdown-item" href="#" (click)="resetConfig(); $event.preventDefault()">
                     <i class="fas fa-fw fa-trash-alt"></i>

--- a/projects/vanilla/src/styles/_uibuilder.scss
+++ b/projects/vanilla/src/styles/_uibuilder.scss
@@ -4,3 +4,7 @@
     max-height: 100px;
   }
 }
+
+.uib-toolbar .btn {
+	color: white !important;
+}

--- a/projects/vanilla/src/styles/app.scss
+++ b/projects/vanilla/src/styles/app.scss
@@ -23,6 +23,7 @@ $dark-link: #9bccff;
 // @import "../../../components/theme/minimal";
 @import "@sinequa/components/theme/sinequa";
 @import "@sinequa/ngx-ui-builder/styles/ui-builder";
+@import "uibuilder";
 
 // File formats & metadata icons
 @import "icons";

--- a/projects/vanilla/src/styles/preview.scss
+++ b/projects/vanilla/src/styles/preview.scss
@@ -92,7 +92,7 @@ $highlights: map-merge(map-merge($extracts-highlights, $terms-highlights), $meta
     $tag-cloud: map-get($highlights, $term);
     $color: map-get($tag-cloud, "main-color");
 
-    .sq-metadata-color-#{$term} {
+    .sq-metadata-item-#{$term} {
         color: $color !important;
 
         &:hover {
@@ -104,7 +104,7 @@ $highlights: map-merge(map-merge($extracts-highlights, $terms-highlights), $meta
           }
     }
 
-    .sq-metadata-color-#{$term}.sq-metadata-border {
+    .sq-metadata-item-#{$term}.sq-metadata-border {
       border: 1px solid $color !important;
     }
 }

--- a/projects/vanilla/src/styles/vanilla.scss
+++ b/projects/vanilla/src/styles/vanilla.scss
@@ -1,6 +1,8 @@
 /****************************************************
   VANILLA-SEARCH
 ****************************************************/
+// tint-color() and shade-color() needs this import
+@use "bootstrap/scss/functions";
 
 // SBA Components
 $dark-result-source-color: #a9c7b4;
@@ -59,6 +61,19 @@ app-search {
 
 .extracts-date {
   font-weight: 500;
+}
+
+// set default colors for unknown metadata
+.sq-metadata-item-values {
+  a.badge {
+    color: black;
+    background-color: whitesmoke;
+
+    &:hover {
+      color: whitesmoke;
+      background-color: black;
+    }
+  }
 }
 
 /****************************************************


### PR DESCRIPTION
* toolbar buttons colors
* fix dropdown menu arrow by specifying the appropriate css class
* fix metadata colors: previously classes are named `sq-metadata-color-<name>` but now it's `sq-metadata-item-<name>`
* fallback color when metadata does not exists in the css file
