### PR TITLE
(chore) update json plugin service parameters types

### DIFF
--- a/projects/vanilla/src/app/toolbar/toolbar.component.ts
+++ b/projects/vanilla/src/app/toolbar/toolbar.component.ts
@@ -38,7 +38,7 @@ export class ToolbarComponent {
     const workspaceName = this.appService.app?.workspaceApp.split('/')[2]; // '/_sba/ws11.5.1.69/projects/vanilla-search/'
     if(workspaceName) {
       const config = this.configService.getAllConfig();
-      const download$ = this.pluginService.post("MakeStaticWorkspace", {workspaceName, config}, {params: {noNotify: true}})
+      const download$ = this.pluginService.post("MakeStaticWorkspace", {workspaceName, config}, {params: {noNotify: true}, responseType: "json"})
         .pipe(
           catchError(err => {
             this.notificationsService.error("Make sure you install the following JSON method plugin: https://github.com/sinequa/sba-vanilla-ui-builder/blob/develop/UiBuilderPlugin.cs")


### PR DESCRIPTION
After Json Method plugin service Typings, vanilla-buider emit an Typescript error.
The Typescript constraint need a responseType value.