### PR TITLE
refactor metadata-configurator

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,10 @@ Vanilla Builder is designed to let Sinequa administrators quickly generate and c
 Vanilla Builder can be built and deployed like any regular SBA in Sinequa:
 
 - Clone this repository
-- Run `npm install`
+- Run `npm install --legacy-peer-deps`
 - Run `npm run build` (to build the app) or `npm run start` (to serve the app locally)
+
+Note that you may also need to setup your `startConfig` variable (inside `projets/vanilla/src/app/app.module.ts`).
 
 Optionally, to enable the export of the application as a static SBA (see [below](#static-export)), deploy the attached `UiBuilderPlugin.cs` plugin on your Sinequa server.
 

--- a/projects/vanilla/src/app/configurators/metadata-configurator.component.ts
+++ b/projects/vanilla/src/app/configurators/metadata-configurator.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnChanges } from "@angular/core";
+import { Component, Input } from "@angular/core";
 import { MetadataConfig } from "@sinequa/components/metadata";
 import { AppService } from "@sinequa/core/app-utils";
 import { ComponentConfig, ConfiguratorContext } from "@sinequa/ngx-ui-builder";
@@ -7,43 +7,132 @@ import { ComponentConfig, ConfiguratorContext } from "@sinequa/ngx-ui-builder";
   selector: 'sq-metadata-configurator',
   template: `
 <div class="form-group">
-  <label for="item">Item</label>
-  <select id="item" class="form-select mb-2" [(ngModel)]="config.item" (ngModelChange)="configChanged(true)">
-    <option *ngFor="let a of metadata" [ngValue]="a.field">{{a.field}}</option>
-  </select>
+  <label class="form-label mt-2">Selection</label>
+  <p class="small text-muted m-0">Select which metadata to display. The order can be changed by dragging the following options up and down.</p>
+  <uib-multi-selector [options]="metadataSelection" [enableReorder]="true" [(ngModel)]="config.items" (ngModelChange)="updatedList()">
+  </uib-multi-selector>
 
-  <uib-checkbox [context]="context" property="clickable" label="Clickable"></uib-checkbox>
-  <uib-checkbox [context]="context" property="showTitle" label="Show title"></uib-checkbox>
-  <uib-checkbox [context]="context" property="showIcon" label="Show icon"></uib-checkbox>
+  <div *ngIf="config.items?.length">
+    <div class="input-group mb-2">
+      <input type="text" class="form-control" [(ngModel)]="metadataString" placeholder="Type a string to insert between metadatas">
+      <div class="input-group-append">
+        <button class="btn btn-secondary" (click)="insertString()">Insert a string</button>
+      </div>
+    </div>
 
-  <div *ngIf="isEntity">
-    Entity options:
-    <uib-checkbox [context]="context" property="showCounts" label="Show counts"></uib-checkbox>
-    <uib-checkbox [context]="context" property="showEntityTooltip" label="Show tooltip"></uib-checkbox>
+    <div class="mb-2">
+      <label class="form-label" for="layout">Layout</label>
+      <select [(ngModel)]="config.layout" id="layout" class="form-select" (ngModelChange)="context.configChanged()">
+        <option value="">Inline</option>
+        <option value="table">Table</option>
+      </select>
+    </div>
+
+    <label class="form-label mt-2" for="item">Customize</label>
+    <select id="item" class="form-select mb-2" [(ngModel)]="modifiedMetadata" (ngModelChangeDebounced)="changedMetadata()">
+      <option [value]="undefined">Select a metadata</option>
+      <option *ngFor="let conf of updatableMetadata" [value]="conf.field">{{conf.field}}</option>
+    </select>
+
+    <ng-container *ngIf="metadataToModify">
+      <div class="mb-2">
+        <label class="form-label" for="label">Label</label>
+        <input type="text" class="form-control mb-1" id="label" [(ngModel)]="metadataToModify.label" (ngModelChangeDebounced)="configChanged()">
+      </div>
+      <div class="mb-2">
+        <sq-icon-selector [config]="metadataToModify" (configChanged)="iconChanged(metadataToModify, $event)"></sq-icon-selector>
+      </div>
+      <div class="mb-2">
+        <label class="form-label" for="fieldClass">Additional CSS classes</label>
+        <input type="text" class="form-control mb-1" id="fieldClass" [(ngModel)]="metadataToModify.fieldClass" (ngModelChangeDebounced)="configChanged()">
+      </div>
+      <div class="form-check mb-2">
+        <input class="form-check-input" type="checkbox" id="filterable" [(ngModel)]="metadataToModify.filterable" (ngModelChangeDebounced)="configChanged()">
+        <label class="form-check-label" for="filterable">Filterable</label>
+      </div>
+      <div class="form-check mb-2">
+        <input class="form-check-input" type="checkbox" id="excludable" [(ngModel)]="metadataToModify.excludable" (ngModelChangeDebounced)="configChanged()">
+        <label class="form-check-label" for="excludable">Excludable</label>
+      </div>
+      <div class="form-check mb-2">
+        <input class="form-check-input" type="checkbox" id="collapseRows" [(ngModel)]="metadataToModify.collapseRows" (ngModelChangeDebounced)="configChanged()">
+        <label class="form-check-label" for="collapseRows">Collapse rows</label>
+      </div>
+      <div class="form-check mb-2" *ngIf="isEntity">
+        <input class="form-check-input" type="checkbox" id="showEntityExtract" [(ngModel)]="metadataToModify.showEntityExtract" (ngModelChangeDebounced)="configChanged()">
+        <label class="form-check-label" for="showEntityExtract">Show entity extract</label>
+      </div>
+      <div class="mb-2" *ngIf="isEntity">
+        <label class="form-label" for="entityExtractMaxLines">Max lines for entity extract</label>
+        <input type="number" class="form-control" id="entityExtractMaxLines" [(ngModel)]="metadataToModify.entityExtractMaxLines">
+      </div>
+    </ng-container>
   </div>
 </div>
     `
 })
-export class MetadataConfiguratorComponent implements OnChanges {
+export class MetadataConfiguratorComponent {
   @Input() context: ConfiguratorContext;
-  @Input() metadata: MetadataConfig[];
+  @Input() metadata: string[];
+  @Input() metadataConfig: MetadataConfig[];
 
+  modifiedMetadata: string;
+  metadataString: string;
+  metadataToModify: MetadataConfig;
   isEntity: boolean;
 
-  constructor(public appService: AppService) {}
-
-  ngOnChanges(): void {
-    this.isEntity = this.appService.isEntity(this.config.item);
-  }
+  constructor(public appService: AppService) { }
 
   get config(): ComponentConfig {
     return this.context.config;
   }
 
-  configChanged(isItem?: boolean) {
-    if (isItem) {
-      this.isEntity = this.appService.isEntity(this.config.item);
-    }
+  get metadataSelection(): string[] {
+    const stringItems = this.config.metadataConfig?.filter(c => !c.field) || [];
+    return this.metadata.concat(stringItems);
+  }
+
+  get updatableMetadata(): MetadataConfig[] {
+    return this.config.metadataConfig?.filter(c => !!c.field) || [];
+  }
+
+  insertString() {
+      if (this.metadataString.trim() !== "") {
+        this.config.metadataConfig.push(this.metadataString);
+        this.config.items.push(this.metadataString);
+        this.metadataString = '';
+        this.configChanged();
+      }
+  }
+
+  configChanged() {
     this.context.configChanged();
+    setTimeout(() => {
+      if (this.metadataToModify) {
+        this.metadataToModify = this.config.metadataConfig.find(m => m.field === this.metadataToModify.field);
+      }
+    })
+  }
+
+  updatedList() {
+    const allMetadata = [...(this.config.metadataConfig || [])].concat(this.metadataConfig);
+    this.config.metadataConfig = this.config.items.map(item => {
+      let metadata: MetadataConfig = allMetadata.find(m => m.field === item || !m.field);
+      if (!metadata) {
+        metadata = { field: item };
+      }
+      return metadata;
+    });
+    this.configChanged();
+  }
+
+  changedMetadata() {
+    this.metadataToModify = this.config.metadataConfig.find(m => m.field === this.modifiedMetadata);
+    this.isEntity = this.appService.isEntity(this.metadataToModify.field);
+  }
+
+  iconChanged(metadata: any, change: { icon: string, iconCode: string }) {
+    Object.assign(metadata, change);
+    this.configChanged();
   }
 }

--- a/projects/vanilla/src/app/configurators/metadata-configurator.component.ts
+++ b/projects/vanilla/src/app/configurators/metadata-configurator.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from "@angular/core";
+import { Component, Input, OnChanges, SimpleChanges } from "@angular/core";
 import { MetadataConfig } from "@sinequa/components/metadata";
 import { AppService } from "@sinequa/core/app-utils";
 import { ComponentConfig, ConfiguratorContext } from "@sinequa/ngx-ui-builder";
@@ -81,7 +81,7 @@ import { ComponentConfig, ConfiguratorContext } from "@sinequa/ngx-ui-builder";
 </div>
     `
 })
-export class MetadataConfiguratorComponent {
+export class MetadataConfiguratorComponent implements OnChanges {
   @Input() context: ConfiguratorContext;
   @Input() metadata: string[];
 
@@ -93,6 +93,12 @@ export class MetadataConfiguratorComponent {
   isEntity: boolean;
 
   constructor(public appService: AppService) { }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes.context && this.metadataToModify) {
+      this.metadataToModify = this.config.metadataConfig.find(m => m.field === this.metadataToModify.field);
+    }
+  }
 
   get config(): ComponentConfig {
     return this.context.config;
@@ -106,11 +112,6 @@ export class MetadataConfiguratorComponent {
  /** Update the whole config */
   configChanged() {
     this.context.configChanged();
-    setTimeout(() => {
-      if (this.metadataToModify) {
-        this.metadataToModify = this.config.metadataConfig.find(m => m.field === this.metadataToModify.field);
-      }
-    })
   }
 
   /** Selecting a metadata to update */

--- a/projects/vanilla/src/app/configurators/preview-configurator.component.ts
+++ b/projects/vanilla/src/app/configurators/preview-configurator.component.ts
@@ -1,5 +1,4 @@
 import { Component, Input, OnInit } from "@angular/core";
-import { MetadataConfig } from "@sinequa/components/metadata";
 import { AppService } from "@sinequa/core/app-utils";
 import { ConfiguratorContext } from "@sinequa/ngx-ui-builder";
 
@@ -19,14 +18,13 @@ import { ConfiguratorContext } from "@sinequa/ngx-ui-builder";
 
   <h6 class="mt-2">Metadata options</h6>
 
-  <sq-metadata-configurator [context]="context" [metadata]="metadata" [metadataConfig]="metadataConfig"></sq-metadata-configurator>
+  <sq-metadata-configurator [context]="context" [metadata]="metadata"></sq-metadata-configurator>
 
   `
 })
 export class PreviewConfiguratorComponent implements OnInit {
   @Input() context: ConfiguratorContext;
   @Input() metadata: string[];
-  @Input() metadataConfig: MetadataConfig[];
 
   highlights: string[];
   extractOptions = [

--- a/projects/vanilla/src/app/configurators/preview-configurator.component.ts
+++ b/projects/vanilla/src/app/configurators/preview-configurator.component.ts
@@ -1,4 +1,5 @@
 import { Component, Input, OnInit } from "@angular/core";
+import { MetadataConfig } from "@sinequa/components/metadata";
 import { AppService } from "@sinequa/core/app-utils";
 import { ConfiguratorContext } from "@sinequa/ngx-ui-builder";
 
@@ -18,22 +19,14 @@ import { ConfiguratorContext } from "@sinequa/ngx-ui-builder";
 
   <h6 class="mt-2">Metadata options</h6>
 
-  <label class="form-label" for="layout">Layout</label>
-  <select [(ngModel)]="context.config.metadata.layout" id="layout" class="form-select" (ngModelChange)="context.configChanged()">
-    <option value="">Inline</option>
-    <option value="table">Table</option>
-  </select>
-
-  <label class="mt-2">Metadata</label>
-  <p class="small text-muted m-0">Select which metadata to display in the preview header. The order of the metadata can be changed by dragging the following options up and down.</p>
-  <uib-multi-selector [options]="metadata" [enableReorder]="true" [(ngModel)]="context.config.metadata.items" (ngModelChange)="context.configChanged()">
-  </uib-multi-selector>
+  <sq-metadata-configurator [context]="context" [metadata]="metadata" [metadataConfig]="metadataConfig"></sq-metadata-configurator>
 
   `
 })
 export class PreviewConfiguratorComponent implements OnInit {
   @Input() context: ConfiguratorContext;
   @Input() metadata: string[];
+  @Input() metadataConfig: MetadataConfig[];
 
   highlights: string[];
   extractOptions = [

--- a/projects/vanilla/src/app/search/search-configurator.component.html
+++ b/projects/vanilla/src/app/search/search-configurator.component.html
@@ -74,7 +74,7 @@
       </ng-template>
 
       <ng-template uib-template="result-metadata" let-context>
-          <sq-metadata-configurator [context]="context" [metadata]="metadata"></sq-metadata-configurator>
+          <sq-metadata-configurator [context]="context" [metadata]="metadata" [metadataConfig]="metadataConfig"></sq-metadata-configurator>
       </ng-template>
 
       <ng-template uib-template="tabs" let-context>
@@ -135,7 +135,7 @@
       </ng-template>
 
       <ng-template uib-template="preview" let-context>
-        <sq-preview-configurator [context]="context" [metadata]="metadata"></sq-preview-configurator>
+        <sq-preview-configurator [context]="context" [metadata]="metadata" [metadataConfig]="metadataConfig"></sq-preview-configurator>
       </ng-template>
 
       <ng-template uib-template="slide-builder" let-context>

--- a/projects/vanilla/src/app/search/search-configurator.component.html
+++ b/projects/vanilla/src/app/search/search-configurator.component.html
@@ -74,7 +74,7 @@
       </ng-template>
 
       <ng-template uib-template="result-metadata" let-context>
-          <sq-metadata-configurator [context]="context" [metadata]="metadata" [metadataConfig]="metadataConfig"></sq-metadata-configurator>
+          <sq-metadata-configurator [context]="context" [metadata]="metadata"></sq-metadata-configurator>
       </ng-template>
 
       <ng-template uib-template="tabs" let-context>
@@ -135,7 +135,7 @@
       </ng-template>
 
       <ng-template uib-template="preview" let-context>
-        <sq-preview-configurator [context]="context" [metadata]="metadata" [metadataConfig]="metadataConfig"></sq-preview-configurator>
+        <sq-preview-configurator [context]="context" [metadata]="metadata"></sq-preview-configurator>
       </ng-template>
 
       <ng-template uib-template="slide-builder" let-context>

--- a/projects/vanilla/src/app/search/search-configurator.component.ts
+++ b/projects/vanilla/src/app/search/search-configurator.component.ts
@@ -18,10 +18,11 @@ export class SearchConfiguratorComponent implements OnDestroy {
    * The configuration from the config.ts file can be overridden by configuration from
    * the app configuration on the server
    */
-  public get metadata(): string[] {
-    const m = this.appService.app?.data?.metadata as any as MetadataConfig[] || METADATA_CONFIG;
-    return m.map(i => i.field);
+  public get metadataConfig(): MetadataConfig[] {
+    return this.appService.app?.data?.metadata as any as MetadataConfig[] || METADATA_CONFIG;
   }
+
+  metadata: string[] = [];
 
   loginService = inject(LoginService);
   appService = inject(AppService);
@@ -35,18 +36,17 @@ export class SearchConfiguratorComponent implements OnDestroy {
   }
 
   ngOnDestroy(): void {
-    if(this.subs) this.subs.unsubscribe();
+    if (this.subs) this.subs.unsubscribe();
   }
 
   private updateMetadata(records: Record[]) {
-    return;
-    // const set = new Set(this.metadata);
-    // records.forEach(r => {
-    //   Object.keys(r)
-    //     .filter(k => this.appService.getColumn(k))
-    //     .forEach(k => set.add(k));
-    // });
-    // this.metadata = [...set.values()]
+    const set = new Set(this.metadata);
+    records.forEach(r => {
+      Object.keys(r)
+      .filter(k => this.appService.getColumn(k))
+      .forEach(k => set.add(k));
+    });
+    return this.metadata = [...set.values()];
   }
 
 }

--- a/projects/vanilla/src/app/search/search-configurator.component.ts
+++ b/projects/vanilla/src/app/search/search-configurator.component.ts
@@ -1,26 +1,16 @@
 import { Component, OnDestroy, inject } from "@angular/core";
-import { MetadataConfig } from "@sinequa/components/metadata";
 import { SearchService } from "@sinequa/components/search";
 import { UIService } from "@sinequa/components/utils";
 import { AppService } from "@sinequa/core/app-utils";
 import { LoginService } from "@sinequa/core/login";
 import { Record, Results } from "@sinequa/core/web-services";
 import { Subscription } from "rxjs";
-import { METADATA_CONFIG } from "../../config";
 
 @Component({
   selector: 'app-search-configurator',
   templateUrl: './search-configurator.component.html'
 })
 export class SearchConfiguratorComponent implements OnDestroy {
-  /**
-   * Returns the configuration of the metadata displayed in the facet-preview component.
-   * The configuration from the config.ts file can be overridden by configuration from
-   * the app configuration on the server
-   */
-  public get metadataConfig(): MetadataConfig[] {
-    return this.appService.app?.data?.metadata as any as MetadataConfig[] || METADATA_CONFIG;
-  }
 
   metadata: string[] = [];
 

--- a/projects/vanilla/src/app/search/search.component.html
+++ b/projects/vanilla/src/app/search/search.component.html
@@ -218,7 +218,7 @@
                 </ng-template>
 
                 <ng-template uib-template="result-metadata" display="Metadata" let-config let-record="data">
-                    <sq-metadata [record]="record" [config]="metadata" [query]="searchService.query"></sq-metadata>
+                    <sq-metadata [record]="record" [config]="config.metadataConfig" [layout]="config.layout" [query]="searchService.query"></sq-metadata>
                 </ng-template>
             </uib-zone>
 
@@ -252,7 +252,7 @@
                         </ng-template>
 
                         <ng-template #subHeaderTpl>
-                            <sq-metadata [record]="record" [config]="getMetadata(config.metadata.items)" [layout]="config.metadata.layout" [query]="searchService.query"></sq-metadata>
+                            <sq-metadata [record]="record" [config]="config.metadataConfig" [layout]="config.layout" [query]="searchService.query"></sq-metadata>
                         </ng-template>
 
                         <ng-template [sqFacetView]="{text: 'msg#preview.viewPassages'}" [default]="true" *ngIf="openedDoc?.$hasPassages" #passagesList>

--- a/projects/vanilla/src/app/search/search.component.ts
+++ b/projects/vanilla/src/app/search/search.component.ts
@@ -274,16 +274,4 @@ export class SearchComponent implements OnInit {
       this.openPreviewIfNoUrl(value.item.$record, value.isLink);
     }
   }
-
-  getMetadata(metadata: string[]): MetadataConfig[] {
-    // we need to respect the metadata order set
-    const list = metadata.reduce((acc, meta) => {
-      const m = this.metadata.find(m => m.field === meta);
-      if (m) {
-        acc.push(m)
-      }
-      return acc;
-    }, [] as MetadataConfig[]);
-    return list;
-  }
 }

--- a/projects/vanilla/src/styles/_uibuilder.scss
+++ b/projects/vanilla/src/styles/_uibuilder.scss
@@ -1,6 +1,6 @@
 // <!-- ui-builder -->
 .uib-zone.edited {
-  sq-facet-tree .list-group.list-group-flush, sq-facet-list .facet-results-scrollable, sq-facet-date > div {
+  sq-facet-list .facet-results-scrollable, sq-facet-date > div {
     max-height: 100px;
   }
 }


### PR DESCRIPTION
Update `sq-metadata-configurator` to fit the new metadata customization. Also use it for the preview.

![image](https://github.com/sinequa/sba-vanilla-ui-builder/assets/8538354/a2bf7858-7a43-40b6-9cae-6a79ef8679e7)

![image](https://github.com/sinequa/sba-vanilla-ui-builder/assets/8538354/effbcaa6-529e-43da-ad73-0ac24e0111f7)


TODO:
- I found issues with the ordering list when manipulating it when it contains some string items