### PR TITLE
ES-28794 #done Configure npm for legacy peer dependency resolution

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 node-options="--max-old-space-size=8192"
+legacy-peer-deps=true


### PR DESCRIPTION
Adds `legacy-peer-deps=true` to the `.npmrc` file. This setting helps resolve potential peer dependency conflicts during `npm install`, ensuring that installations can proceed without errors related to peer dependency mismatches, especially in projects with complex or older dependency trees.